### PR TITLE
(#21) Search Terms Without Definition

### DIFF
--- a/cypress/integration/DefinitionEnglish.feature
+++ b/cypress/integration/DefinitionEnglish.feature
@@ -37,4 +37,10 @@ Feature: As a user I would like to see the Definition box when I navigate to the
 		And link to the definition page with text "More information on dictionary page" does not display
 		And button to toggle the full definition in the definition box labelled "Show full definition" does not display
 
+	Scenario: English Dictionary Definition Display - do not show definition box
+		Given the user navigates to "/?swKeyword=dceg"
+		Then the page title is "NCI Search Results"
+		And page subtitle "Results for: dceg" appears below the page title
+		And definition box does not appear on the page
+
 

--- a/cypress/integration/common/index.js
+++ b/cypress/integration/common/index.js
@@ -69,6 +69,10 @@ And('definition box appears with title {string}', (definitionBoxTitle) => {
 	cy.get('div.definition h2').should('have.text', definitionBoxTitle);
 });
 
+And('definition box does not appear on the page', () => {
+	cy.get('div.definition').should('not.exist');
+});
+
 And(
 	'the word {string} appears in the definition box, with the audio icon and pronunciation',
 	(term) => {

--- a/src/components/molecules/definition/definition.jsx
+++ b/src/components/molecules/definition/definition.jsx
@@ -7,9 +7,10 @@ import { i18n, splitSentencesToArray } from '../../../utils';
 
 const Definition = ({ results }) => {
 	const payload = results[0];
-	const definitionSentencesArray = splitSentencesToArray(
-		payload.definition.html
-	);
+	const definitionSentencesArray =
+		payload && payload.definition
+			? splitSentencesToArray(payload.definition.html)
+			: '';
 	const truncatedDefinition = definitionSentencesArray[0];
 	const [{ glossaryURL, language }] = useStateValue();
 	const [defToggleClassName, setDefToggleClassName] = useState(

--- a/src/components/molecules/search-results-list/results-list-item.jsx
+++ b/src/components/molecules/search-results-list/results-list-item.jsx
@@ -13,7 +13,7 @@ const ResultsListItem = ({ result = {}, language = 'en' }) => {
 	const test = /- National Cancer Institute|- Instituto Nacional del Cáncer$/i;
 	// Quick check to find empty title tags for documents
 	const sanitizedTitle =
-		title.length < 1 ? 'Untitled ' : title.replace(test, '').trim();
+		!title || title.length < 1 ? 'Untitled ' : title.replace(test, '').trim();
 
 	const displayType =
 		contentType === 'cgvInfographic' || contentType === 'cgvVideo';

--- a/support/mock-data/Search/cgov/en/all/dceg.json
+++ b/support/mock-data/Search/cgov/en/all/dceg.json
@@ -1,0 +1,125 @@
+{
+	"results": [
+		{
+			"title": "PowerPoint Presentation",
+			"url": "https://www.cancer.gov/about-nci/contracts/fnlcr-acquisitions/resources/files/dceg.pptx",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "iCURE - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/organization/crchd/diversity-training/icure",
+			"contentType": "cgvArticle",
+			"description": "iCURE supports mentored research experiences for students and scientists in the NCI research community. iCURE encourages the participation of underrepresented individuals."
+		},
+		{
+			"title": "AORTIC 2019: CGH engages with partners at the largest cancer research conference in Africa - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/organization/cgh/blog/2019/aortic",
+			"contentType": "cgvBlogPost",
+			"description": "CGH attends AORTIC 2019 annual meeting, meets with partners, and leads cancer research and control satellite meetings and sessions."
+		},
+		{
+			"title": "Intramural Research - National Cancer Institute",
+			"url": "https://www.cancer.gov/research/nci-role/intramural",
+			"contentType": "cgvArticle",
+			"description": "The intramural research program supports projects conducted by scientists located at NCI."
+		},
+		{
+			"title": "New on NCI’s Websites - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2015/new-online-december-2015",
+			"contentType": "cgvBlogPost",
+			"description": "NCI periodically provides updates on new websites and other online content of interest to the cancer community."
+		},
+		{
+			"title": "NCI Graduate Student Recruiting Program - National Cancer Institute",
+			"url": "https://www.cancer.gov/grants-training/training/idwb/student-recruiting-program",
+			"contentType": "cgvArticle",
+			"description": "NCI’s Graduate Student Recruiting Program provides postdoctoral fellows an opportunity to complete their training in the Intramural Research Program. Learn more about the benefits of the program and how to apply."
+		},
+		{
+			"title": "New on NCI’s Websites for December 2017 - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2017/new-online-december-2017",
+			"contentType": "cgvBlogPost",
+			"description": "An NCI Cancer Currents blog post that provides an update on new content of interest to the cancer community recently added to NCI’s websites."
+		},
+		{
+			"title": "New on NCI Websites, March 2018 - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2018/new-online-march-2018",
+			"contentType": "cgvBlogPost",
+			"description": "An NCI Cancer Currents blog post that provides an update on new content of interest to the cancer community recently added to NCI’s websites."
+		},
+		{
+			"title": null,
+			"url": "https://www.cancer.gov/about-nci/contracts/opportunities/bidboard/75n91019q00161-rc.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "Research Areas: Causes of Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/research/areas/causes",
+			"contentType": "cgvArticle",
+			"description": "Understanding the exposures and risk factors that cause cancer, as well as the genetic abnormalities associated with the disease, has helped us to reduce certain exposures and to ameliorate their harmful effects."
+		},
+		{
+			"title": "Research Areas: Prevention - National Cancer Institute",
+			"url": "https://www.cancer.gov/research/areas/prevention",
+			"contentType": "cgvArticle",
+			"description": "NCI’s prevention research has a broad focus, from identifying environmental and lifestyle factors that influence cancer risk to studying the biology of how cancer develops and studying ways to disseminate prevention interventions."
+		},
+		{
+			"title": "2018 NCI Budget Fact Book - Obligations by Mechanism and Division - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/budget/fact-book/data/obligations",
+			"contentType": "cgvArticle",
+			"description": "See obligations for the 2018 fiscal year by budget mechanism and division, including grants, contracts, training fellowships, intramural research, and management and support."
+		},
+		{
+			"title": "New on NCI Websites for June 2018 - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2018/new-online-june-2018",
+			"contentType": "cgvBlogPost",
+			"description": "NCI’s online collection of cancer information products is constantly growing. See selected content of interest to the cancer community that has been added as of June 2018 in this Cancer Currents blog post."
+		},
+		{
+			"title": "New on NCI’s Websites for March 2020 - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2020/new-online-march-2020",
+			"contentType": "cgvBlogPost",
+			"description": "See selected content that has been added to NCI’s websites as of March 2020, in this Cancer Currents blog post."
+		},
+		{
+			"title": "Research Areas: Cancer Genomics - National Cancer Institute",
+			"url": "https://www.cancer.gov/research/areas/genomics",
+			"contentType": "cgvArticle",
+			"description": "Investigating the genetic foundations of cancer has improved our understanding of cancer biology and led to better prevention, diagnosis and treatment methods."
+		},
+		{
+			"title": "Celebrating National Minority Health Month 2017 - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/organization/crchd/blog/2017/nci-nmhm-2017",
+			"contentType": "cgvBlogPost",
+			"description": "NCI and other organizations recognize National Minority Health Month in April 2017."
+		},
+		{
+			"title": "What’s New Online from NCI? - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2015/new-online-july-2015",
+			"contentType": "cgvBlogPost",
+			"description": "NCI periodically provides updates on new websites and other online content of interest to the cancer community."
+		},
+		{
+			"title": "New on NCI’s Websites for August 2016 - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2016/new-online-august-2016",
+			"contentType": "cgvBlogPost",
+			"description": "NCI periodically provides updates on new websites and other online content of interest to the cancer community."
+		},
+		{
+			"title": "DCEG Research - National Cancer Institute",
+			"url": "https://dceg.cancer.gov/research",
+			"contentType": "cgvMiniLanding",
+			"description": "DCEG investigators conduct multidisciplinary research to discover the genetic and environmental determinants of cancer and the means of prevention"
+		},
+		{
+			"title": "Subcontracting Opportunities - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/contracts/opportunities/subcontracting",
+			"contentType": "cgvArticle",
+			"description": "Explore the different ways to find NCI subcontracting opportunities."
+		}
+	],
+	"totalResults": 1971
+}


### PR DESCRIPTION
Closes #21

* Fixed definition display issue when no results are returned for term
* Fixed results display issue when there's no title for returned payload
* Added integration test for definition box when no results are returned