### PR TITLE
(#6) Display BestBets and Definition

### DIFF
--- a/cypress/integration/BasicResultsPageOtherSites/DCEGBasicResults.feature
+++ b/cypress/integration/BasicResultsPageOtherSites/DCEGBasicResults.feature
@@ -38,8 +38,8 @@ Feature: As a user, I want to be able to see my search results on DCEG, navigate
         Given the user navigates to "/?swKeyword=cancer"
         Then "<meta name='robots' content='noindex' />" exists in the data for the page URL of "/?swKeyword=cancer"
 
-        Scenario: Best bets is not displayed 
-		Given the user navigates to "/?swKeyword=cancer%20risk%20assessment%20tools"
-		Then the page title is "DCEG Search Results"
-		And the system displays "Results for: " "cancer risk assessment tools" as an "h3" tag
-		Then a box for Best Bets is not displayed
+    Scenario: Best bets is not displayed
+        Given the user navigates to "/?swKeyword=cancer%20risk%20assessment%20tools"
+        Then the page title is "DCEG Search Results"
+        And the system displays "Results for: " "cancer risk assessment tools" as an "h3" tag
+        Then a box for Best Bets is not displayed

--- a/cypress/integration/BestBetsAndDictionaryDisplay.feature
+++ b/cypress/integration/BestBetsAndDictionaryDisplay.feature
@@ -1,0 +1,86 @@
+Feature: As a content editor, I would like to display both the best bets and definition of a term at the top of search results
+
+    Scenario: English display Search results, Best Bets and Definition together
+        Given the user navigates to "/?swKeyword=carcinoma"
+        Then the page title is "NCI Search Results"
+        And the system displays "Results for: " "carcinoma" as an "h3" tag
+        And a box for Best Bets appears below the subtitle
+        And the system displays best bet number 1 title "Best Bets for Carcinoma" as an "h2" tag
+        And the title of the related item number 1 appears as a link with text "What Is Cancer?"
+        And definition box appears with title "Definition:"
+        And the word "carcinoma" appears in the definition box, with the audio icon and pronunciation
+        When user navigates to the next page
+        Then a box for Best Bets is not displayed
+        And definition box does not appear on the page
+
+    Scenario: Spanish display Best Bets and Definition together
+        Given "language" is set to "es"
+        And "dictionaryUrl" is set to "https://www.cancer.gov/espanol/publicaciones/diccionario"
+        And "title" is set to "Resultados"
+        When the user navigates to "/?swKeyword=carcinoma"
+        Then the page title is "Resultados"
+        And the system displays "Resultados para: " "carcinoma" as an "h3" tag
+        And a box for Best Bets appears below the subtitle
+        And the system displays best bet number 1 title "Mejores resultados para Carcinoma (en español)" as an "h2" tag
+        And the title of the related item number 1 appears as a link with text "Tipos de cáncer"
+        And definition box appears with title "Definición:"
+        And the word "carcinoma" appears in the definition box with the audio icon
+        When user navigates to the next page
+        Then a box for Best Bets is not displayed
+        And definition box does not appear on the page
+
+    Scenario: English display Search results, Best Bets and Definition together on Mobile
+        Given screen breakpoint is set to "mobile"
+        Given the user navigates to "/?swKeyword=carcinoma"
+        Then the page title is "NCI Search Results"
+        And the system displays "Results for: " "carcinoma" as an "h3" tag
+        And a box for Best Bets appears below the subtitle
+        And the system displays best bet number 1 title "Best Bets for Carcinoma" as an "h2" tag
+        And the title of the related item number 1 appears as a link with text "What Is Cancer?"
+        And definition box appears with title "Definition:"
+        And the word "carcinoma" appears in the definition box, with the audio icon and pronunciation
+        And each result item displays the title of an item as a link
+        When user navigates to the next page
+        Then a box for Best Bets is not displayed
+        And definition box does not appear on the page
+
+
+    Scenario: English display only Search results and Definition when bestbets endpoint is not provided
+        Given "bestbetsEndpoint" is set to "null"
+        And the user navigates to "/?swKeyword=carcinoma"
+        Then the page title is "NCI Search Results"
+        And the system displays "Results for: " "carcinoma" as an "h3" tag
+        Then a box for Best Bets is not displayed
+        And definition box appears with title "Definition:"
+        And the word "carcinoma" appears in the definition box, with the audio icon and pronunciation
+        And each result item displays the title of an item as a link
+        When user navigates to the next page
+        Then a box for Best Bets is not displayed
+        And definition box does not appear on the page
+
+
+    Scenario: English display only Search results and BestBets when glossary endpoint is not provided
+        Given "glossaryEndpoint" is set to "null"
+        And the user navigates to "/?swKeyword=carcinoma"
+        Then the page title is "NCI Search Results"
+        And the system displays "Results for: " "carcinoma" as an "h3" tag
+        And a box for Best Bets appears below the subtitle
+        And definition box does not appear on the page
+        And the system displays best bet number 1 title "Best Bets for Carcinoma" as an "h2" tag
+        And the title of the related item number 1 appears as a link with text "What Is Cancer?"
+        And each result item displays the title of an item as a link
+        When user navigates to the next page
+        Then a box for Best Bets is not displayed
+        And definition box does not appear on the page
+
+    Scenario: English display only Search results when glossary endpoint and BestBets endpoint is not provided
+        Given "glossaryEndpoint" is set to "null"
+        And "bestbetsEndpoint" is set to "null"
+        When the user navigates to "/?swKeyword=carcinoma"
+        Then the page title is "NCI Search Results"
+        And the system displays "Results for: " "carcinoma" as an "h3" tag
+        And the system displays "Results 1-20 of 2946 for: " "carcinoma" as an "h4" tag
+        And each result item displays the title of an item as a link
+        Then a box for Best Bets is not displayed
+        And definition box does not appear on the page
+

--- a/src/components/molecules/definition/__tests__/definition.test.js
+++ b/src/components/molecules/definition/__tests__/definition.test.js
@@ -87,6 +87,67 @@ describe('Definition component (English)', () => {
 			container.querySelector('button.definition__show-full')
 		).toHaveTextContent('Show full definition');
 	});
+	test('should not display if payload has no results', () => {
+		const definitionResult = {
+			meta: {
+				totalResults: 0,
+				from: 0,
+			},
+			results: [],
+		};
+		useStateValue.mockReturnValue([
+			{
+				appId: 'mockAppId',
+				dictionaryUrl:
+					'https://www.cancer.gov/publications/dictionaries/cancer-terms',
+				language: 'en',
+			},
+		]);
+		const { container } = render(<Definition {...definitionResult} />);
+		expect(container.querySelector('definition__term-description')).toBeNull();
+	});
+	test('should not display more info link when there are no related sources or media', () => {
+		const definitionResult = {
+			meta: {
+				totalResults: 1,
+				from: 0,
+			},
+			results: [
+				{
+					termId: 45333,
+					language: 'en',
+					dictionary: 'Cancer.gov',
+					audience: 'Patient',
+					termName: 'cancer',
+					firstLetter: 'c',
+					prettyUrlName: null,
+					pronunciation: {
+						key: '(KAN-ser)',
+						audio: 'https://nci-media.cancer.gov/pdq/media/audio/705333.mp3',
+					},
+					definition: {
+						html:
+							'A term for diseases in which abnormal cells divide without control and can invade nearby tissues. Cancer cells can also spread to other parts of the body through the blood and lymph systems. There are several main types of cancer. Carcinoma is a cancer that begins in the skin or in tissues that line or cover internal organs. Sarcoma is a cancer that begins in bone, cartilage, fat, muscle, blood vessels, or other connective or supportive tissue. Leukemia is a cancer that begins in blood-forming tissue, such as the bone marrow, and causes too many abnormal blood cells to be made. Lymphoma and multiple myeloma are cancers that begin in the cells of the immune system. Central nervous system cancers are cancers that begin in the tissues of the brain and spinal cord. Also called malignancy.',
+						text:
+							'A term for diseases in which abnormal cells divide without control and can invade nearby tissues. Cancer cells can also spread to other parts of the body through the blood and lymph systems. There are several main types of cancer. Carcinoma is a cancer that begins in the skin or in tissues that line or cover internal organs. Sarcoma is a cancer that begins in bone, cartilage, fat, muscle, blood vessels, or other connective or supportive tissue. Leukemia is a cancer that begins in blood-forming tissue, such as the bone marrow, and causes too many abnormal blood cells to be made. Lymphoma and multiple myeloma are cancers that begin in the cells of the immune system. Central nervous system cancers are cancers that begin in the tissues of the brain and spinal cord. Also called malignancy.',
+					},
+					otherLanguages: [],
+					relatedResources: [],
+					media: [],
+				},
+			],
+		};
+		useStateValue.mockReturnValue([
+			{
+				appId: 'mockAppId',
+				dictionaryUrl:
+					'https://www.cancer.gov/publications/dictionaries/cancer-terms',
+				language: 'en',
+			},
+		]);
+		const { container } = render(<Definition {...definitionResult} />);
+		expect(container.querySelector('p a')).toBeNull();
+	});
 });
 
 describe('Definition component (Spanish)', () => {

--- a/src/components/molecules/definition/definition.scss
+++ b/src/components/molecules/definition/definition.scss
@@ -2,8 +2,7 @@
 	padding: 16px 19px 10px;
 	border-radius: 3px;
 	box-shadow: 0 0 4px 0 hsla(0,0%,71%,.75);
-	margin-bottom: 40px;
-	
+
 	&__toggle {
 		border-top: 1px solid #c7c6c6;
 		margin-left: -19px;

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -44,10 +44,15 @@ const Home = () => {
 	const [current] = useState(currentPage);
 	const isFirstPage = !urlQuery.get('page') || urlQuery.get('page') === '1';
 
-	const showBestBet = isBestBetsConfigured && isFirstPage;
+	const showBestBet =
+		isBestBetsConfigured && stateBestBetResult?.length > 0 && isFirstPage;
 	// Only display Definition component if isDictionaryConfigured is true
+	// and no results returned
 	// and offset doesn't exist in url or it exists and is the first page
-	const showDefinition = isDictionaryConfigured && isFirstPage;
+	const showDefinition =
+		isDictionaryConfigured &&
+		stateDefinitionResult?.results?.length > 0 &&
+		isFirstPage;
 
 	const tracking = useTracking();
 	// Fetch dictionary results only when
@@ -158,10 +163,17 @@ const Home = () => {
 			{doneLoading && hasResults ? (
 				<div className="results">
 					<h3>{`${i18n.resultsFor[language]}: ${keyword}`}</h3>
-					{showDefinition && <Definition {...stateDefinitionResult} />}
-					{showBestBet && (
-						<BestBet language={language} results={stateBestBetResult} />
-					)}
+					<div
+						className={
+							showBestBet && showDefinition
+								? 'results__feature--bestbet--definition'
+								: 'results__feature'
+						}>
+						{showBestBet && (
+							<BestBet language={language} results={stateBestBetResult} />
+						)}
+						{showDefinition && <Definition {...stateDefinitionResult} />}
+					</div>
 					<SearchResultsList
 						keyword={keyword}
 						language={language}

--- a/src/views/Home/Home.scss
+++ b/src/views/Home/Home.scss
@@ -1,14 +1,67 @@
+@import '../../styles/breakpoints';
+
 .results {
 	h2 {
 		font-size: 1.25em;
 		line-height: 1.5em;
-		margin-bottom: .5em;
+		margin-bottom: 0.5em;
 		margin-top: 0;
 	}
-	h3, h4 {
+	h3,
+	h4 {
 		font-size: 1.25em;
 		line-height: 1.5em;
 		margin-top: 40px;
 		margin-bottom: 30px;
 	}
+
+	/*
+		--------------------------------------
+		Feature Box for BestBet and Definition
+		--------------------------------------
+	*/
+	&__feature {
+		margin-bottom: 40px;
+	}
+	&__feature--bestbet--definition {
+		position: relative;
+		margin-left: -3.125em;
+		margin-right: -3.125em;
+		margin-bottom: 50px;
+		display: flex;
+		flex-wrap: wrap;
+		padding: 2.5% 3.125em;
+		background-color: #dbf2f8;
+		align-items: flex-start;
+		justify-content: center;
+
+		.best-bet {
+			margin-bottom: 1em;
+			background-color: transparent;
+		}
+
+		.definition {
+			flex: 33.33333% 1;
+			margin-bottom: 0;
+			background-color: #fff;
+		}
+	}
+}
+
+@include break(medium) {
+	.results {
+		&__feature--bestbet--definition {
+			.best-bet {
+				flex: 66.66667% 1;
+				margin-left: 0;
+				margin-right: 0;
+				padding-right: 0.9375em;
+
+				.best-bet__item {
+					padding: 0;
+				}
+			}
+		}
+	}
+
 }

--- a/support/mock-data/Search/cgov/en/all/carcinoma_0-20.json
+++ b/support/mock-data/Search/cgov/en/all/carcinoma_0-20.json
@@ -1,0 +1,131 @@
+{
+    "results": [
+      {
+        "title": "NUT Carcinoma - National Cancer Institute",
+        "url": "https://www.cancer.gov/pediatric-adult-rare-tumor/rare-tumors/rare-soft-tissue-tumors/nut-carcinoma",
+        "contentType": "cgvArticle",
+        "description": "NUT carcinoma, also known as NUT midline carcinoma, is a type of rare cancer that can grow anywhere in the body. Usually, it is found in the head, neck, and lungs."
+      },
+      {
+        "title": "Fibrolamellar Carcinoma - National Cancer Institute",
+        "url": "https://www.cancer.gov/pediatric-adult-rare-tumor/rare-tumors/rare-digestive-system-tumors/fibrolamellar-hepatocellular-carcinoma",
+        "contentType": "cgvArticle",
+        "description": "Fibrolamellar Carcinoma, or FLC, is a rare cancer of the liver that usually grows in teens and adults under 40 years old. It is unsusal because it occurs in people who have healthy livers. Learn more about how this cancer forms, is treated, and the prognosis."
+      },
+      {
+        "title": "Adrenocortical Carcinoma - National Cancer Institute",
+        "url": "https://www.cancer.gov/pediatric-adult-rare-tumor/rare-tumors/rare-endocrine-tumor/adrenocortical-carcinoma",
+        "contentType": "cgvArticle",
+        "description": "Adrenocortical carcinoma, or ACC, is a cancer of the adrenal glands, which are two small triangular-shaped glands that sit on top of each kidney. It is very rare, afffecting around one in one million people in the US annually.  Learn more about diagnosis, treatement, and prognosis of this disease."
+      },
+      {
+        "title": "Childhood Basal Cell Carcinoma and Squamous Cell Carcinoma of the Skin Treatment (PDQ®)–Patient Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/skin/patient/child-skin-treatment-pdq",
+        "contentType": "pdqCancerInfoSummary",
+        "description": "The primary treatment of childhood basal cell carcinoma and squamous cell carcinoma of the skin is surgery. Learn more about the risk factors, symptoms, tests to diagnose, and treatment of childhood basal cell carcinoma and squamous cell carcinoma of the skin in this expert-reviewed summary."
+      },
+      {
+        "title": "Childhood Midline Tract Carcinoma Involving the NUT Gene (NUT Midline Carcinoma) Treatment (PDQ®)–Health Professional Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/midline/hp-child-midline-tract-carcinoma-treatment-pdq",
+        "contentType": "pdqCancerInfoSummary",
+        "description": "Treatment options for children with midline tract carcinoma involving the NUT gene (NUT Midline Carcinoma) include chemotherapy, surgery, and radiation therapy. Get detailed treatment information for newly diagnosed and recurrent childhood NUT midline carcinoma in this summary for clinicians."
+      },
+      {
+        "title": "Childhood Basal Cell Carcinoma and Squamous Cell Carcinoma of the Skin Treatment (PDQ®)–Health Professional Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/skin/hp/child-skin-treatment-pdq",
+        "contentType": "pdqCancerInfoSummary",
+        "description": "This evidence-based, expert-reviewed summary discusses the incidence, risk factors, clinical presentation, diagnosis, and treatment of pediatric basal cell carcinoma and squamous cell carcinoma of the skin."
+      },
+      {
+        "title": "Adrenocortical Carcinoma—Health Professional Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/adrenocortical/hp",
+        "contentType": "cgvCancerTypeHome",
+        "description": "Adrenocortical carcinoma is also called cancer of the adrenal cortex. A tumor of the adrenal cortex may be functioning or nonfunctioning. Most adrenocortical tumors are functioning. Find evidence-based information on adrenocortical carcinoma including treatment and research."
+      },
+      {
+        "title": "Merkel Cell Carcinoma Treatment (PDQ®)–Patient Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/skin/patient/merkel-cell-treatment-pdq",
+        "contentType": "pdqCancerInfoSummary",
+        "description": "Merkel cell carcinoma is a rare type of skin cancer that usually starts in areas of skin exposed to the sun. Sun exposure and having a weak immune system can affect the risk of Merkel cell  carcinoma.  Merkel cell carcinoma usually appears as a single painless lump on sun-exposed skin. Find out more about risk factors, symptoms, tests to diagnose, prognosis, staging, and treatment for Merkel cell carcinoma."
+      },
+      {
+        "title": "Adrenocortical Carcinoma Treatment (Adult) (PDQ®)–Patient Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/adrenocortical/patient/adrenocortical-treatment-pdq",
+        "contentType": "pdqCancerInfoSummary",
+        "description": "Adrenocortical carcinoma (also called ACC or adrenal cancer) treatment usually involves surgery and may include radiation therapy and chemotherapy. Learn about risk factors, symptoms, diagnosis, prognosis, and treatment for newly diagnosed and recurrent ACC in this expert-reviewed summary."
+      },
+      {
+        "title": "Adrenocortical Carcinoma—Patient Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/adrenocortical",
+        "contentType": "cgvCancerTypeHome",
+        "description": "Adrenocortical carcinoma is a rare cancer which forms in the cortex (outer layer) of an adrenal gland. There are two adrenal glands. One sits on top of each kidney. Start here to find information on adrenocortical carcinoma treatment and research."
+      },
+      {
+        "title": "Childhood Adrenocortical Carcinoma Treatment (PDQ®)–Patient Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/adrenocortical/patient/child-adrenocortical-treatment-pdq",
+        "contentType": "pdqCancerInfoSummary",
+        "description": "Treatment for childhood adrenocortical cancer (cancer of the adrenal cortex) is surgery to remove the tumor. Learn more about the risk factors, symptoms, tests to diagnose, prognosis, and treatment of childhood adrenocortical cancer in this expert-reviewed summary."
+      },
+      {
+        "title": "Carcinoma of Unknown Primary Treatment (PDQ®)–Patient Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/unknown-primary/patient/unknown-primary-treatment-pdq",
+        "contentType": "pdqCancerInfoSummary",
+        "description": "Carcinoma of unknown primary (CUP), treatment can include surgery, radiation therapy, chemotherapy, or hormone therapy. Get detailed information about the diagnosis and treatment of CUP in this expert-reviewed summary."
+      },
+      {
+        "title": "Translocation Renal Cell Carcinoma - National Cancer Institute",
+        "url": "https://www.cancer.gov/pediatric-adult-rare-tumor/rare-tumors/rare-kidney-tumors/translocation-renal-cell-carcinoma",
+        "contentType": "cgvArticle",
+        "description": "Translocation renal cell carcinoma is a type of cancer that grows in the kidney."
+      },
+      {
+        "title": "Papillary Renal Cell Carcinoma - National Cancer Institute",
+        "url": "https://www.cancer.gov/pediatric-adult-rare-tumor/rare-tumors/rare-kidney-tumors/papillary-renal-cell-carcinoma",
+        "contentType": "cgvArticle",
+        "description": "Papillary renal cell carcinoma is a type of cancer that grows in the kidney."
+      },
+      {
+        "title": "Thymoma and Thymic Carcinoma—Patient Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/thymoma",
+        "contentType": "cgvCancerTypeHome",
+        "description": "Thymomas and thymic carcinomas are rare tumors that form in cells on the thymus. Thymomas grow slowly and rarely spread beyond the thymus. Thymic carcinoma grows faster, often spreads to other parts of the body, and is harder to treat. Start here to find information on thymoma and thymic carcinoma treatment."
+      },
+      {
+        "title": "Adrenocortical Carcinoma Research - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/adrenocortical/research",
+        "contentType": "cgvCancerResearch",
+        "description": "Find research articles on adrenocortical carcinoma, which may include news stories, clinical trials, blog posts, and descriptions of active studies."
+      },
+      {
+        "title": "Thymoma and Thymic Carcinoma—Health Professional Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/thymoma/hp",
+        "contentType": "cgvCancerTypeHome",
+        "description": "Thymomas and thymic carcinomas are epithelial tumors of the thymus. A thymic epithelial tumor that exhibits cytologic atypia and histologic features no longer specific to the thymus is known as a thymic carcinoma. Find evidence-based information on thymoma and thymic carcinoma treatment."
+      },
+      {
+        "title": "Carcinoma of Unknown Primary—Health Professional Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/unknown-primary/hp",
+        "contentType": "cgvCancerTypeHome",
+        "description": "Carcinoma of unknown primary (CUP) is a rare disease in which malignant cells are found in the body but the site of the primary cancer is not known. Most CUPs are adenocarcinomas, or undifferentiated tumors. Find evidence-based information on the treatment for carcinoma of unknown primary."
+      },
+      {
+        "title": "Carcinoma of Unknown Primary—Patient Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/unknown-primary",
+        "contentType": "cgvCancerTypeHome",
+        "description": "Carcinoma of unknown primary (CUP) occurs when cancer cells have spread in the body and formed metastatic tumors but the site of the primary cancer is not known. There are a number of reasons why the primary cancer may not be found. Start here to find treatment information for carcinoma of unknown primary."
+      },
+      {
+        "title": "Thymoma and Thymic Carcinoma Treatment (Adult) (PDQ®)–Patient Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/thymoma/patient/thymoma-treatment-pdq",
+        "contentType": "pdqCancerInfoSummary",
+        "description": "Thymoma and thymic carcinoma treatment options include surgery, radiation therapy, chemotherapy, chemoradiation, and hormone therapy. Learn more about the treatments for newly diagnosed and recurrent thymoma and thymic carcinoma in this expert-reviewed summary."
+      },
+      {
+        "title": "Adrenocortical Carcinoma Treatment (Adult) (PDQ®)–Health Professional Version - National Cancer Institute",
+        "url": "https://www.cancer.gov/types/adrenocortical/hp/adrenocortical-treatment-pdq",
+        "contentType": "pdqCancerInfoSummary",
+        "description": "Adrenocortical carcinoma (ACC or adrenal cancer) treatment is usually radical open complete resection and may include chemotherapy and radiation. Get detailed information about the prognosis and treatment of newly diagnosed and recurrent ACC in this comprehensive summary for clinicians."
+      }
+    ],
+    "totalResults": 2946
+  }

--- a/support/mock-data/bestbets/v1/BestBets/live/en/carcinoma.json
+++ b/support/mock-data/bestbets/v1/BestBets/live/en/carcinoma.json
@@ -1,0 +1,8 @@
+[
+    {
+      "html": "<div class=\"managed list\">\n<ul>\n<li class=\"general-list-item general list-item\">\n<!-- cgvSnListItemGeneral -->\n<!-- Image -->\n<!-- End Image -->\n<div class=\"title-and-desc title desc container\"><a class=\"title\" href=\"/about-cancer/understanding/what-is-cancer\">What Is Cancer?</a><!-- start description -->\n<div class=\"description\"><p class=\"body\">Understand how cancer cells differ from normal cells and genetics changes that cause cancer to grow and spread.</p></div><!-- end description --></div><!-- end title & desc container -->\n</li></ul>\n</div>",
+      "id": "35832",
+      "name": "Carcinoma",
+      "weight": 7
+    }
+  ]

--- a/support/mock-data/bestbets/v1/BestBets/live/es/carcinoma.json
+++ b/support/mock-data/bestbets/v1/BestBets/live/es/carcinoma.json
@@ -1,0 +1,8 @@
+[
+    {
+      "html": "<div class=\"managed list\">\n<ul>\n<li class=\"general-list-item general list-item\">\n<!-- cgvSnListItemGeneral -->\n<!-- Image -->\n<!-- End Image -->\n<div class=\"title-and-desc title desc container\"><a class=\"title\" href=\"/espanol/tipos\">Tipos de cáncer</a><!-- start description -->\n<div class=\"description\"><p class=\"body\">Lista alfabética de todos los tipos de cáncer con enlaces a enfermedades específicas e información general sobre tratamiento, cuidados de apoyo, exámenes de detección, prevención, estudios clínicos y otros temas.</p></div><!-- end description --></div><!-- end title & desc container -->\n</li></ul>\n</div>",
+      "id": "73719",
+      "name": "Carcinoma (en español)",
+      "weight": 5
+    }
+  ]

--- a/support/mock-data/glossary/v1/Terms/search/Cancer.gov/Patient/en/carcinoma.json
+++ b/support/mock-data/glossary/v1/Terms/search/Cancer.gov/Patient/en/carcinoma.json
@@ -1,0 +1,35 @@
+{
+    "meta": {
+      "totalResults": 1,
+      "from": 0
+    },
+    "results": [
+      {
+        "termId": 45963,
+        "language": "en",
+        "dictionary": "Cancer.gov",
+        "audience": "Patient",
+        "termName": "carcinoma",
+        "firstLetter": "c",
+        "prettyUrlName": "carcinoma",
+        "pronunciation": {
+          "key": "(KAR-sih-NOH-muh)",
+          "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/707516.mp3"
+        },
+        "definition": {
+          "html": "Cancer that begins in the skin or in tissues that line or cover internal organs.",
+          "text": "Cancer that begins in the skin or in tissues that line or cover internal organs."
+        },
+        "otherLanguages": [
+          {
+            "language": "es",
+            "termName": "carcinoma",
+            "prettyUrlName": "carcinoma"
+          }
+        ],
+        "relatedResources": [],
+        "media": []
+      }
+    ],
+    "links": null
+  }

--- a/support/mock-data/glossary/v1/Terms/search/Cancer.gov/Patient/es/carcinoma.json
+++ b/support/mock-data/glossary/v1/Terms/search/Cancer.gov/Patient/es/carcinoma.json
@@ -1,0 +1,35 @@
+{
+    "meta": {
+      "totalResults": 1,
+      "from": 0
+    },
+    "results": [
+      {
+        "termId": 45963,
+        "language": "es",
+        "dictionary": "Cancer.gov",
+        "audience": "Patient",
+        "termName": "carcinoma",
+        "firstLetter": "c",
+        "prettyUrlName": "carcinoma",
+        "pronunciation": {
+          "key": null,
+          "audio": "https://nci-media-dev.cancer.gov/pdq/media/audio/707515.mp3"
+        },
+        "definition": {
+          "html": "Cáncer que empieza en la piel o en los tejidos que revisten o cubren los órganos internos.",
+          "text": "Cáncer que empieza en la piel o en los tejidos que revisten o cubren los órganos internos."
+        },
+        "otherLanguages": [
+          {
+            "language": "en",
+            "termName": "carcinoma",
+            "prettyUrlName": "carcinoma"
+          }
+        ],
+        "relatedResources": [],
+        "media": []
+      }
+    ],
+    "links": null
+  }


### PR DESCRIPTION
Closes #6

* Added blank placeholder styling
* Added feature container for BestBet and Definition
* Added styling for feature box (BestBet & Definition display)
* Added integration tests for bestBets and definition display
* Updated styling for smaller viewports and width adjustments for flexbox
* Temporary tone down of branch coverage (WILL BE REVERTED)
* Updates for conforming to BEM style
* Boosted unit test coverage
* Restored branch coverage threshold (REVERTED)