### PR TITLE
(#49) fix low level security vulnerabilities with npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@nciocpl/sitewide-search-app",
-	"version": "0.1.0-beta.1",
+	"version": "1.0.0-beta.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5269,48 +5269,48 @@
 			"integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
 		},
 		"cypress": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/cypress/-/cypress-4.9.0.tgz",
-			"integrity": "sha512-qGxT5E0j21FPryzhb0OBjCdhoR/n1jXtumpFFSBPYWsaZZhNaBvc3XlBUDEZKkkXPsqUFYiyhWdHN/zo0t5FcA==",
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/cypress/-/cypress-4.12.0.tgz",
+			"integrity": "sha512-ZDngKMwoQ2UYmeSUJikLMZG6t2N7lTHHlzBzh5W0MbPfXSMv36YUgL2ZVD+t4ZLA63WWkvhwxIkDG+WJknBgHw==",
 			"dev": true,
 			"requires": {
-				"@cypress/listr-verbose-renderer": "0.4.1",
-				"@cypress/request": "2.88.5",
-				"@cypress/xvfb": "1.2.4",
-				"@types/sinonjs__fake-timers": "6.0.1",
-				"@types/sizzle": "2.3.2",
-				"arch": "2.1.2",
-				"bluebird": "3.7.2",
-				"cachedir": "2.3.0",
-				"chalk": "2.4.2",
-				"check-more-types": "2.24.0",
-				"cli-table3": "0.5.1",
-				"commander": "4.1.1",
-				"common-tags": "1.8.0",
-				"debug": "4.1.1",
-				"eventemitter2": "6.4.2",
-				"execa": "1.0.0",
-				"executable": "4.1.1",
-				"extract-zip": "1.7.0",
-				"fs-extra": "8.1.0",
-				"getos": "3.2.1",
-				"is-ci": "2.0.0",
-				"is-installed-globally": "0.3.2",
-				"lazy-ass": "1.6.0",
-				"listr": "0.14.3",
-				"lodash": "4.17.15",
-				"log-symbols": "3.0.0",
-				"minimist": "1.2.5",
-				"moment": "2.26.0",
-				"ospath": "1.2.2",
-				"pretty-bytes": "5.3.0",
-				"ramda": "0.26.1",
-				"request-progress": "3.0.0",
-				"supports-color": "7.1.0",
-				"tmp": "0.1.0",
-				"untildify": "4.0.0",
-				"url": "0.11.0",
-				"yauzl": "2.10.0"
+				"@cypress/listr-verbose-renderer": "^0.4.1",
+				"@cypress/request": "^2.88.5",
+				"@cypress/xvfb": "^1.2.4",
+				"@types/sinonjs__fake-timers": "^6.0.1",
+				"@types/sizzle": "^2.3.2",
+				"arch": "^2.1.2",
+				"bluebird": "^3.7.2",
+				"cachedir": "^2.3.0",
+				"chalk": "^2.4.2",
+				"check-more-types": "^2.24.0",
+				"cli-table3": "~0.5.1",
+				"commander": "^4.1.1",
+				"common-tags": "^1.8.0",
+				"debug": "^4.1.1",
+				"eventemitter2": "^6.4.2",
+				"execa": "^1.0.0",
+				"executable": "^4.1.1",
+				"extract-zip": "^1.7.0",
+				"fs-extra": "^8.1.0",
+				"getos": "^3.2.1",
+				"is-ci": "^2.0.0",
+				"is-installed-globally": "^0.3.2",
+				"lazy-ass": "^1.6.0",
+				"listr": "^0.14.3",
+				"lodash": "^4.17.19",
+				"log-symbols": "^3.0.0",
+				"minimist": "^1.2.5",
+				"moment": "^2.27.0",
+				"ospath": "^1.2.2",
+				"pretty-bytes": "^5.3.0",
+				"ramda": "~0.26.1",
+				"request-progress": "^3.0.0",
+				"supports-color": "^7.1.0",
+				"tmp": "~0.1.0",
+				"untildify": "^4.0.0",
+				"url": "^0.11.0",
+				"yauzl": "^2.10.0"
 			},
 			"dependencies": {
 				"bluebird": {
@@ -6691,9 +6691,9 @@
 			}
 		},
 		"eventemitter2": {
-			"version": "6.4.2",
-			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.2.tgz",
-			"integrity": "sha512-r/Pwupa5RIzxIHbEKCkNXqpEQIIT4uQDxmP4G/Lug/NokVUWj0joz/WzWl3OxRpC5kDrH/WdiUJoR+IrwvXJEw==",
+			"version": "6.4.3",
+			"resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
+			"integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==",
 			"dev": true
 		},
 		"eventemitter3": {
@@ -10075,9 +10075,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.15",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"version": "4.17.19",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
 		},
 		"lodash._reinterpolate": {
 			"version": "3.0.0",
@@ -10755,9 +10755,9 @@
 			}
 		},
 		"moment": {
-			"version": "2.26.0",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-			"integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw==",
+			"version": "2.27.0",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+			"integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
 			"dev": true
 		},
 		"move-concurrently": {

--- a/package.json
+++ b/package.json
@@ -201,10 +201,13 @@
 		"reporter": [
 			"text",
 			"json"
+		],
+		"exclude": [
+			"**/node_modules/**"
 		]
 	},
 	"devDependencies": {
-		"cypress": "^4.8.0",
+		"cypress": "^4.12.0",
 		"cypress-cucumber-preprocessor": "^2.5.0",
 		"eslint-config-airbnb": "^18.1.0",
 		"eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
Closes #49 .

This should be **last** story merged in.

Should remove the comment noting detection of 5400+ low level security vulnerabilities when installing the application.

No visual changes but requesting @kate-mashkina and QA review because cypress does get updated and want to make sure it doesn't break anything.