### PR TITLE
(#61) Analytics: Page Load Capture for Best Bet\Dictionary display

### DIFF
--- a/cypress/integration/AppAnalytics/BasicSearchResultsPageLoad.feature
+++ b/cypress/integration/AppAnalytics/BasicSearchResultsPageLoad.feature
@@ -1,32 +1,130 @@
 Feature: Basic search results Page Load
 
+	Scenario: Page Load Analytics fires when a user views search result page with Best Bet and Definition
+		Given "resultsPageTitle" is set to "NCI Search Results"
+		And "searchCollection" is set to "cgov"
+		And "language" is set to "en"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "National Cancer Institute"
+		And "channel" is set to "Search"
+		And "analyticsContentGroup" is set to "Global Search"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		When the user navigates to "/?swKeyword=tumor"
+		And the system displays "Results 1-20 of 11556 for: " "tumor" as an "h4" tag
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                      | value                                          |
+			| type                                     | PageLoad                                       |
+			| event                                    | SiteWideSearchApp:Load:Results                 |
+			| page.name                                | www.cancer.gov/?swKeyword=tumor                |
+			| page.title                               | NCI Search Results                             |
+			| page.metaTitle                           | NCI Search Results - National Cancer Institute |
+			| page.language                            | english                                        |
+			| page.type                                | nciAppModulePage                               |
+			| page.channel                             | Search                                         |
+			| page.contentGroup                        | Global Search                                  |
+			| page.publishedDate                       | 02/02/2011                                     |
+			| page.additionalDetails.numberResults     | (int)11556                                     |
+			| page.additionalDetails.searchKeyword     | tumor                                          |
+			| page.additionalDetails.itemsPerPage      | (int)20                                        |
+			| page.additionalDetails.pageNum           | (int)1                                         |
+			| page.additionalDetails.showingBestBets   | (bool)true                                     |
+			| page.additionalDetails.showingDefinition | (bool)true                                     |
 
-    Scenario: Page Load Analytics fires when a user views search result page
-        Given "resultsPageTitle" is set to "NCI Search Results"
-        And "searchCollection" is set to "cgov"
-        And "language" is set to "en"
-        And "baseHost" is set to "http://localhost:3000"
-        And "canonicalHost" is set to "https://www.cancer.gov"
-        And "siteName" is set to "National Cancer Institute"
-        And "channel" is set to "Search"
-        And "analyticsContentGroup" is set to "Global Search"
-        And "analyticsPublishedDate" is set to "02/02/2011"
-        When the user navigates to "/?swKeyword=tumor"
-        And the system displays "Results 1-20 of 11556 for: " "tumor" as an "h4" tag
-        And browser waits
-        Then there should be an analytics event with the following details
-            | key                                  | value                                          |
-            | type                                 | PageLoad                                       |
-            | event                                | SiteWideSearchApp:Load:Results                 |
-            | page.name                            | www.cancer.gov/?swKeyword=tumor                |
-            | page.title                           | NCI Search Results                             |
-            | page.metaTitle                       | NCI Search Results - National Cancer Institute |
-            | page.language                        | english                                        |
-            | page.type                            | nciAppModulePage                               |
-            | page.channel                         | Search                                         |
-            | page.contentGroup                    | Global Search                                  |
-            | page.publishedDate                   | 02/02/2011                                     |
-            | page.additionalDetails.numberResults | (int)11556                                     |
-            | page.additionalDetails.searchKeyword | tumor                                          |
-            | page.additionalDetails.itemsPerPage  | (int)20                                        |
-            | page.additionalDetails.pageNum       | (int)1                                         |
+	Scenario: Page Load Analytics fires when a user views second page search result with Best Bet and Definition not displayed
+		Given "resultsPageTitle" is set to "NCI Search Results"
+		And "searchCollection" is set to "cgov"
+		And "language" is set to "en"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "National Cancer Institute"
+		And "channel" is set to "Search"
+		And "analyticsContentGroup" is set to "Global Search"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		When the user navigates to "/?swKeyword=tumor&page=2&pageunit=20"
+		And the system displays "Results 21-40 of 11556 for: " "tumor" as an "h4" tag
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                      | value                                              |
+			| type                                     | PageLoad                                           |
+			| event                                    | SiteWideSearchApp:Load:Results                     |
+			| page.name                                | www.cancer.gov/?swKeyword=tumor&page=2&pageunit=20 |
+			| page.title                               | NCI Search Results                                 |
+			| page.metaTitle                           | NCI Search Results - National Cancer Institute     |
+			| page.language                            | english                                            |
+			| page.type                                | nciAppModulePage                                   |
+			| page.channel                             | Search                                             |
+			| page.contentGroup                        | Global Search                                      |
+			| page.publishedDate                       | 02/02/2011                                         |
+			| page.additionalDetails.numberResults     | (int)11556                                         |
+			| page.additionalDetails.searchKeyword     | tumor                                              |
+			| page.additionalDetails.itemsPerPage      | (int)20                                            |
+			| page.additionalDetails.pageNum           | (int)2                                             |
+			| page.additionalDetails.showingBestBets   | (bool)false                                        |
+			| page.additionalDetails.showingDefinition | (bool)false                                        |
+
+	Scenario: Page Load Analytics fires when a user views search result page with Best Bet not displayed and Definition displayed
+		Given "resultsPageTitle" is set to "NCI Search Results"
+		And "searchCollection" is set to "cgov"
+		And "language" is set to "en"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "National Cancer Institute"
+		And "channel" is set to "Search"
+		And "analyticsContentGroup" is set to "Global Search"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		When the user navigates to "/?swKeyword=cancer"
+		And the system displays "Results 1-20 of 30283 for: " "cancer" as an "h4" tag
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                      | value                                          |
+			| type                                     | PageLoad                                       |
+			| event                                    | SiteWideSearchApp:Load:Results                 |
+			| page.name                                | www.cancer.gov/?swKeyword=cancer               |
+			| page.title                               | NCI Search Results                             |
+			| page.metaTitle                           | NCI Search Results - National Cancer Institute |
+			| page.language                            | english                                        |
+			| page.type                                | nciAppModulePage                               |
+			| page.channel                             | Search                                         |
+			| page.contentGroup                        | Global Search                                  |
+			| page.publishedDate                       | 02/02/2011                                     |
+			| page.additionalDetails.numberResults     | (int)30283                                     |
+			| page.additionalDetails.searchKeyword     | cancer                                         |
+			| page.additionalDetails.itemsPerPage      | (int)20                                        |
+			| page.additionalDetails.pageNum           | (int)1                                         |
+			| page.additionalDetails.showingBestBets   | (bool)false                                    |
+			| page.additionalDetails.showingDefinition | (bool)true                                     |
+
+	Scenario: Page Load Analytics fires when a user views search result page with Best Bet displayed and Definition not displayed
+		Given "resultsPageTitle" is set to "NCI Search Results"
+		And "searchCollection" is set to "cgov"
+		And "language" is set to "en"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "National Cancer Institute"
+		And "channel" is set to "Search"
+		And "analyticsContentGroup" is set to "Global Search"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		When the user navigates to "/?swKeyword=ctep"
+		And the system displays "Results 1-20 of 799 for: " "ctep" as an "h4" tag
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                      | value                                          |
+			| type                                     | PageLoad                                       |
+			| event                                    | SiteWideSearchApp:Load:Results                 |
+			| page.name                                | www.cancer.gov/?swKeyword=ctep                 |
+			| page.title                               | NCI Search Results                             |
+			| page.metaTitle                           | NCI Search Results - National Cancer Institute |
+			| page.language                            | english                                        |
+			| page.type                                | nciAppModulePage                               |
+			| page.channel                             | Search                                         |
+			| page.contentGroup                        | Global Search                                  |
+			| page.publishedDate                       | 02/02/2011                                     |
+			| page.additionalDetails.numberResults     | (int)799                                       |
+			| page.additionalDetails.searchKeyword     | ctep                                           |
+			| page.additionalDetails.itemsPerPage      | (int)20                                        |
+			| page.additionalDetails.pageNum           | (int)1                                         |
+			| page.additionalDetails.showingBestBets   | (bool)true                                     |
+			| page.additionalDetails.showingDefinition | (bool)false                                    |
+

--- a/cypress/integration/AppAnalytics/BestBetsLinkClick.feature
+++ b/cypress/integration/AppAnalytics/BestBetsLinkClick.feature
@@ -12,7 +12,7 @@ Feature: As a user, when I click on BestBets link I should be raising an analyti
         And "analyticsContentGroup" is set to "Global Search"
         And "analyticsPublishedDate" is set to "02/02/2011"
         When the user navigates to "/?swKeyword=ctep"
-        And the system displays "Results 1-20 of 797 for: " "ctep" as an "h4" tag
+        And the system displays "Results 1-20 of 799 for: " "ctep" as an "h4" tag
         When user clicks on a title of related item number 1
         Then there should be an analytics event with the following details
             | key                   | value                                    |

--- a/cypress/integration/AppAnalytics/NoResultsFoundPageLoad.feature
+++ b/cypress/integration/AppAnalytics/NoResultsFoundPageLoad.feature
@@ -1,4 +1,5 @@
 Feature: No Results Found Analytics
+
 	Scenario: Page Load Analytics fires when a user searches for a keyword
 		Given  "title" is set to "NCI Search Results"
 		And "language" is set to "en"
@@ -12,18 +13,21 @@ Feature: No Results Found Analytics
 		And the page displays "0 results found for: achoo"
 		And browser waits
 		Then there should be an analytics event with the following details
-			| key                                  | value                                          |
-			| type                                 | PageLoad                                       |
-			| event                                | SiteWideSearchApp:Load:Results                 |
-			| page.name                            | www.cancer.gov/?swKeyword=achoo                |
-			| page.title                           | NCI Search Results                             |
-			| page.metaTitle                       | NCI Search Results - National Cancer Institute |
-			| page.language                        | english                                        |
-			| page.type                            | nciAppModulePage                               |
-			| page.channel                         | Search                                         |
-			| page.contentGroup                    | Global Search                                  |
-			| page.publishedDate                   | 02/02/2011                                     |
-			| page.additionalDetails.searchKeyword | achoo                                          |
-			| page.additionalDetails.numberResults | (int)0                                         |
-			| page.additionalDetails.itemsPerPage  | (int)20                                        |
-			| page.additionalDetails.pageNum       | (int)1                                         |
+			| key                                      | value                                          |
+			| type                                     | PageLoad                                       |
+			| event                                    | SiteWideSearchApp:Load:Results                 |
+			| page.name                                | www.cancer.gov/?swKeyword=achoo                |
+			| page.title                               | NCI Search Results                             |
+			| page.metaTitle                           | NCI Search Results - National Cancer Institute |
+			| page.language                            | english                                        |
+			| page.type                                | nciAppModulePage                               |
+			| page.channel                             | Search                                         |
+			| page.contentGroup                        | Global Search                                  |
+			| page.publishedDate                       | 02/02/2011                                     |
+			| page.additionalDetails.searchKeyword     | achoo                                          |
+			| page.additionalDetails.numberResults     | (int)0                                         |
+			| page.additionalDetails.itemsPerPage      | (int)20                                        |
+			| page.additionalDetails.pageNum           | (int)1                                         |
+			| page.additionalDetails.showingBestBets   | (bool)false                                    |
+			| page.additionalDetails.showingDefinition | (bool)false                                    |
+

--- a/cypress/integration/BestBetsEnglish.feature
+++ b/cypress/integration/BestBetsEnglish.feature
@@ -8,7 +8,7 @@ Feature: As a content editor, I would like to identify content for users to find
 		And the system displays best bet number 1 title "Best Bets for Cancer Therapy Evaluation Program (CTEP)" as an "h2" tag
 		And the title of the related item number 1 appears as a link with text "Cancer Therapy Evaluation Program (CTEP)"
 		And the description of the item number 1 appears below the title
-		And the system displays "Results 1-20 of 797 for: " "ctep" as an "h4" tag
+		And the system displays "Results 1-20 of 799 for: " "ctep" as an "h4" tag
 		And the system displays 20 results per page
 		When user navigates to the next page
 		Then a box for Best Bets is not displayed

--- a/cypress/integration/common/analytics.js
+++ b/cypress/integration/common/analytics.js
@@ -10,6 +10,9 @@ const convertValue = (val) => {
 		if (val.indexOf('(int)') === 0) {
 			return parseInt(val.replace('(int)', ''))
 		}
+		if (val.indexOf('(bool)') === 0) {
+			return val.indexOf('true') >= 0;
+		}
 	}
 	return val;
 }

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -142,6 +142,8 @@ const Home = () => {
 				pageNum: current || 1,
 				itemsPerPage: pageunit || 20,
 				searchKeyword: keyword,
+				showingBestBets: showBestBet,
+				showingDefinition: showDefinition,
 				title,
 				type: 'PageLoad',
 			});

--- a/support/mock-data/Search/cgov/en/all/achoo.json
+++ b/support/mock-data/Search/cgov/en/all/achoo.json
@@ -1,4 +1,0 @@
-{
-	"results": [],
-	"totalResults": 0
-}

--- a/support/mock-data/Search/cgov/en/all/cancer_0-20.json
+++ b/support/mock-data/Search/cgov/en/all/cancer_0-20.json
@@ -37,16 +37,16 @@
 			"description": "Treatment for pediatric liver cancer depends on many factors, including the type of cancer and whether it has spread. When possible, liver cancer is removed by surgery. Learn about the types of treatment options for childhood liver cancers."
 		},
 		{
-			"title": "Lung Cancer Screening (PDQ®)–Health Professional Version - National Cancer Institute",
-			"url": "https://www.cancer.gov/types/lung/hp/lung-screening-pdq",
-			"contentType": "pdqCancerInfoSummary",
-			"description": "Lung cancer screening with low-dose spiral CT scans has been shown to decrease the risk of dying from lung cancer in heavy smokers. Screening with chest x-ray or sputum cytology does not reduce lung cancer mortality. Get detailed information about lung cancer screening in this clinician summary."
-		},
-		{
 			"title": "Stomach (Gastric) Cancer Prevention (PDQ®)–Patient Version - National Cancer Institute",
 			"url": "https://www.cancer.gov/types/stomach/patient/stomach-prevention-pdq",
 			"contentType": "pdqCancerInfoSummary",
 			"description": "Stomach (gastric) cancer risk factors include smoking and H. pylori. Learn about these and other risk factors for stomach cancer and how to prevent stomach cancer in this expert-reviewed and evidence-based summary."
+		},
+		{
+			"title": "Lung Cancer Screening (PDQ®)–Health Professional Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/lung/hp/lung-screening-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Lung cancer screening with low-dose spiral CT scans has been shown to decrease the risk of dying from lung cancer in heavy smokers. Screening with chest x-ray or sputum cytology does not reduce lung cancer mortality. Get detailed information about lung cancer screening in this clinician summary."
 		},
 		{
 			"title": "Cancer Prevention Overview (PDQ®)–Patient Version - National Cancer Institute",
@@ -59,7 +59,67 @@
 			"url": "https://www.cancer.gov/types/skin/patient/skin-screening-pdq",
 			"contentType": "pdqCancerInfoSummary",
 			"description": "Having a skin exam to screen for skin cancer has not been shown to decrease your chance of dying from skin cancer. Learn about this and other tests that have been studied to detect or screen for skin cancer in this expert reviewed summary."
+		},
+		{
+			"title": "Rare Cancers of Childhood Treatment (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/childhood-cancers/patient/rare-childhood-cancers-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Treatment for rare cancers of childhood depends on the specific cancer (e.g., nasopharyngeal, thyroid, oral, laryngeal, lung, esophageal, cardiac). See the full list of treatment summaries for these cancers in this expert-reviewed summary."
+		},
+		{
+			"title": "Esophageal Cancer Screening (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/esophageal/patient/esophageal-screening-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Esophageal cancer screening is not currently considered to be a routine part of cancer screening. Not all screening tests are helpful, and many have risks. Learn more about esophageal cancer risk factors and tests to detect it in this expert-reviewed summary."
+		},
+		{
+			"title": "Liver (Hepatocellular) Cancer Screening (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/liver/patient/liver-screening-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Liver (hepatocellular) cancer screening is not currently recommended as a routine part of cancer screening. Not all screening tests are helpful, and many have risks. Learn more about liver cancer and the tests used to detect it in this expert-reviewed summary."
+		},
+		{
+			"title": "Childhood Breast Cancer Treatment (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/breast/patient/child-breast-treatment-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Most breast masses in children are not cancer. When breast cancer occurs in children, treatment options include surgery and radiation therapy. Learn more about the risk factors, symptoms, tests to diagnose, and treatment of childhood breast cancer in this expert-reviewed summary."
+		},
+		{
+			"title": "Bladder Cancer Treatment (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/bladder/patient/bladder-treatment-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Treatment of bladder cancer depends on the stage of the cancer. Treatment options include different types of surgery (transurethral resection, radical and partial cystectomy, and urinary diversion), radiation therapy, chemotherapy, and immunotherapy. Learn more about how bladder cancer is treated."
+		},
+		{
+			"title": "Endometrial Cancer Prevention (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/uterine/patient/endometrial-prevention-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Endometrial cancer prevention strategies include avoiding risk factors when possible and increasing protective factors that may help prevent cancer. Learn more about known risk and protective factors and approaches to prevent endometrial cancer in this expert-reviewed summary."
+		},
+		{
+			"title": "Gallbladder Cancer Treatment (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/gallbladder/patient/gallbladder-treatment-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Types of treatment for gallbladder cancer include surgery, radiation, and chemotherapy. Treatment of gallbladder cancer that has spread to other parts of the body, cannot be removed by surgery, or has come back after treatment is often within a clinical trial. Find out about treatment options for gallbladder cancer."
+		},
+		{
+			"title": "Liver (Hepatocellular) Cancer Prevention (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/liver/patient/liver-prevention-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Liver cancer risk factors include hepatitis B and C, cirrhosis, and aflatoxin (poison from certain foods). Learn about these and other risk factors for liver cancer and how to prevent liver cancer in this expert-reviewed and evidence-based summary."
+		},
+		{
+			"title": "Lung Cancer Screening (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/lung/patient/lung-screening-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Lung cancer screening with low-dose spiral CT scans has been shown to decrease the risk of dying from lung cancer in heavy smokers. Learn more about tests to detect lung cancer and their potential benefits and harms in this expert-reviewed summary."
+		},
+		{
+			"title": "Cancer Screening Overview (PDQ®)–Health Professional Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-cancer/screening/hp-screening-overview-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Cancer screening can reduce some cancer mortality and morbidity, but potential harms must be weighed against any potential benefits. Get detailed, peer-reviewed and evidence-based information about cancer screening in this overview for clinicians."
 		}
 	],
-	"totalResults": 29835
+	"totalResults": 30283
 }

--- a/support/mock-data/Search/cgov/en/all/ctep_0-20.json
+++ b/support/mock-data/Search/cgov/en/all/ctep_0-20.json
@@ -1,125 +1,125 @@
 {
-    "results": [
-      {
-        "title": "Public Summary",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idscsymposium-meetingsummary.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "Public Summary",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/nctn/gynecologic/public-summary-01-11-13.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "CCCT - Investigational Drug Steering Committee - National Cancer Institute",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug",
-        "contentType": "cgvArticle",
-        "description": "The Investigational Drug Steering Committee (IDSC) collaborates with NCI in the design and prioritization of early phase drug development trials conducted by the Experimental Therapeutics Clinical Trials Network (ETCTN)."
-      },
-      {
-        "title": "2016 Social Media Events - National Cancer Institute",
-        "url": "https://www.cancer.gov/news-events/events/social-media/2016",
-        "contentType": "cgvMiniLanding",
-        "description": "Find past social media events involving NCI and its partners from 2016."
-      },
-      {
-        "title": "Microsoft Word - Acronym List from July 2012 PASC call_final.doc",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/patient-advocate/pasc-acronym-list.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "CCCT Funding Opportunities - BIQSFP FAQs - National Cancer Institute",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/funding/biqsfp/faq",
-        "contentType": "cgvArticle",
-        "description": "Find a list of frequently asked questions related to Biomarker, Imaging and Quality of Life Studies Funding Program (BIQSFP)."
-      },
-      {
-        "title": "IDSC Newsletter_Oct2011.pub",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idsc-newsletter-oct2011.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "Microsoft Word - IDSC Structure and SOP v119 05-15-17.docx",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idsc-sop-structure.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "Clinical Trials Reporting Program (CTRP)",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/ctrp/access-training/ctrp-strategic-subcommittee-report-2011-07.pdf",
-        "contentType": null,
-        "description": "AACI – NCI CLINICAL TRIALS REPORTING PROGRAM (CTRP) STRATEGIC SUBCOMMITTEE REPORT"
-      },
-      {
-        "title": "IDSC Newsletter_SEPT2012.pub",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idsc-newsletter-sept2012.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "IDSC Newsletter_Feb2012.pub",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idscnewsletter-feb2012.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "IDSC NEWSLETTER Vol. 3, Issue 2",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idscnewsletter-june2011-v2.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "IDSC Newsletter_Feb2013.pub",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idsc-newsletter-feb2013.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "IDSC Newsletter_MAY2012.pub",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idscnewsletter-may2012.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "CCCT - CTRP - Registration, Amendments, Updates - National Cancer Institute",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/ctrp/registration",
-        "contentType": "cgvArticle",
-        "description": "Policies on clinical trial registration, amendments and updates related to CTRP."
-      },
-      {
-        "title": "FY20 BIQSFP Guidelines",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/funding/biqsfp/fy20-biqsfp-guidelines.pdf",
-        "contentType": null,
-        "description": "FY20 BIQSFP Guidelines"
-      },
-      {
-        "title": "CCCT - CTRP - Accrual Reporting - National Cancer Institute",
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/ctrp/accrual",
-        "contentType": "cgvArticle",
-        "description": "An overview of accrual reporting requirements of clinical trials into the Clinical Trial Reporting Program."
-      },
-      {
-        "title": null,
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/funding/biqsfp/cea-study-eval-guide.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": null,
-        "url": "https://www.cancer.gov/about-nci/organization/ccct/funding/biqsfp/cea-study-checklist.pdf",
-        "contentType": null,
-        "description": null
-      },
-      {
-        "title": "About CTEP | CTEP",
-        "url": "https://ctep.cancer.gov/about/default.htm",
-        "contentType": null,
-        "description": null
-      }
-    ],
-    "totalResults": 797
-  }
+	"results": [
+		{
+			"title": "Public Summary",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idscsymposium-meetingsummary.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "Public Summary",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/nctn/gynecologic/public-summary-01-11-13.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "Microsoft Word - Acronym List from July 2012 PASC call_final.doc",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/patient-advocate/pasc-acronym-list.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "CCCT - Investigational Drug Steering Committee - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug",
+			"contentType": "cgvArticle",
+			"description": "The Investigational Drug Steering Committee (IDSC) collaborates with NCI in the design and prioritization of early phase drug development trials conducted by the Experimental Therapeutics Clinical Trials Network (ETCTN)."
+		},
+		{
+			"title": "2016 Social Media Events - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/events/social-media/2016",
+			"contentType": "cgvMiniLanding",
+			"description": "Find past social media events involving NCI and its partners from 2016."
+		},
+		{
+			"title": "IDSC Newsletter_Oct2011.pub",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idsc-newsletter-oct2011.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "Microsoft Word - IDSC Structure and SOP v119 05-15-17.docx",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idsc-sop-structure.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "Clinical Trials Reporting Program (CTRP)",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/ctrp/access-training/ctrp-strategic-subcommittee-report-2011-07.pdf",
+			"contentType": null,
+			"description": "AACI – NCI CLINICAL TRIALS REPORTING PROGRAM (CTRP) STRATEGIC SUBCOMMITTEE REPORT"
+		},
+		{
+			"title": "CCCT Funding Opportunities - BIQSFP FAQs - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/funding/biqsfp/faq",
+			"contentType": "cgvArticle",
+			"description": "Find a list of frequently asked questions related to Biomarker, Imaging and Quality of Life Studies Funding Program (BIQSFP)."
+		},
+		{
+			"title": "IDSC Newsletter_SEPT2012.pub",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idsc-newsletter-sept2012.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "IDSC Newsletter_Feb2012.pub",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idscnewsletter-feb2012.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "IDSC NEWSLETTER Vol. 3, Issue 2",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idscnewsletter-june2011-v2.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "IDSC Newsletter_Feb2013.pub",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idsc-newsletter-feb2013.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "IDSC Newsletter_MAY2012.pub",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/steering-committees/investigational-drug/idscnewsletter-may2012.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "CCCT - CTRP - Registration, Amendments, Updates - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/ctrp/registration",
+			"contentType": "cgvArticle",
+			"description": "Policies on clinical trial registration, amendments and updates related to CTRP."
+		},
+		{
+			"title": "FY20 BIQSFP Guidelines",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/funding/biqsfp/fy20-biqsfp-guidelines.pdf",
+			"contentType": null,
+			"description": "FY20 BIQSFP Guidelines"
+		},
+		{
+			"title": null,
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/funding/biqsfp/cea-study-eval-guide.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": null,
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/funding/biqsfp/cea-study-checklist.pdf",
+			"contentType": null,
+			"description": null
+		},
+		{
+			"title": "CCCT - CTRP - Accrual Reporting - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/organization/ccct/ctrp/accrual",
+			"contentType": "cgvArticle",
+			"description": "An overview of accrual reporting requirements of clinical trials into the Clinical Trial Reporting Program."
+		},
+		{
+			"title": "Related NCI Initiatives - National Cancer Institute",
+			"url": "https://www.cancer.gov/nano/about/nci-initiatives",
+			"contentType": "cgvArticle",
+			"description": "The NCI has many initiatives that help to propel the next generation of enabling technologies for cancer.  Find links to these initiatives and programs here."
+		}
+	],
+	"totalResults": 799
+}

--- a/support/mock-data/bestbets/v1/BestBets/live/en/tumor.json
+++ b/support/mock-data/bestbets/v1/BestBets/live/en/tumor.json
@@ -1,0 +1,8 @@
+[
+	{
+		"html": "<div class=\"managed list\">\n<ul>\n<li class=\"general-list-item general list-item\">\n<!-- cgvSnListItemGeneral -->\n<!-- Image -->\n<!-- End Image -->\n<div class=\"title-and-desc title desc container\"><a class=\"title\" href=\"/about-cancer/understanding/what-is-cancer\">What Is Cancer?</a><!-- start description -->\n<div class=\"description\"><p class=\"body\">Understand how cancer cells differ from normal cells and genetics changes that cause cancer to grow and spread.</p></div><!-- end description --></div><!-- end title & desc container -->\n</li></ul>\n</div>",
+		"id": "36268",
+		"name": "What Is a Tumor?",
+		"weight": 11
+	}
+]


### PR DESCRIPTION
Closes #61

* Added `showingBestBets` and `showingDefinition` properties to page load tracking
* Updated and added additional integration tests
* Added boolean evaluation to `analytics.js`