### PR TITLE
(#65) Analytics: Remove querystring from page name for PageLoad event

### DIFF
--- a/cypress/integration/AppAnalytics/BasicSearchResultsPageLoad.feature
+++ b/cypress/integration/AppAnalytics/BasicSearchResultsPageLoad.feature
@@ -17,7 +17,7 @@ Feature: Basic search results Page Load
 			| key                                      | value                                          |
 			| type                                     | PageLoad                                       |
 			| event                                    | SiteWideSearchApp:Load:Results                 |
-			| page.name                                | www.cancer.gov/?swKeyword=tumor                |
+			| page.name                                | www.cancer.gov/								                |
 			| page.title                               | NCI Search Results                             |
 			| page.metaTitle                           | NCI Search Results - National Cancer Institute |
 			| page.language                            | english                                        |
@@ -49,7 +49,7 @@ Feature: Basic search results Page Load
 			| key                                      | value                                              |
 			| type                                     | PageLoad                                           |
 			| event                                    | SiteWideSearchApp:Load:Results                     |
-			| page.name                                | www.cancer.gov/?swKeyword=tumor&page=2&pageunit=20 |
+			| page.name                                | www.cancer.gov/																	  |
 			| page.title                               | NCI Search Results                                 |
 			| page.metaTitle                           | NCI Search Results - National Cancer Institute     |
 			| page.language                            | english                                            |
@@ -81,7 +81,7 @@ Feature: Basic search results Page Load
 			| key                                      | value                                          |
 			| type                                     | PageLoad                                       |
 			| event                                    | SiteWideSearchApp:Load:Results                 |
-			| page.name                                | www.cancer.gov/?swKeyword=cancer               |
+			| page.name                                | www.cancer.gov/								                |
 			| page.title                               | NCI Search Results                             |
 			| page.metaTitle                           | NCI Search Results - National Cancer Institute |
 			| page.language                            | english                                        |
@@ -113,7 +113,7 @@ Feature: Basic search results Page Load
 			| key                                      | value                                          |
 			| type                                     | PageLoad                                       |
 			| event                                    | SiteWideSearchApp:Load:Results                 |
-			| page.name                                | www.cancer.gov/?swKeyword=ctep                 |
+			| page.name                                | www.cancer.gov/							                  |
 			| page.title                               | NCI Search Results                             |
 			| page.metaTitle                           | NCI Search Results - National Cancer Institute |
 			| page.language                            | english                                        |

--- a/cypress/integration/AppAnalytics/NoResultsFoundPageLoad.feature
+++ b/cypress/integration/AppAnalytics/NoResultsFoundPageLoad.feature
@@ -16,7 +16,7 @@ Feature: No Results Found Analytics
 			| key                                      | value                                          |
 			| type                                     | PageLoad                                       |
 			| event                                    | SiteWideSearchApp:Load:Results                 |
-			| page.name                                | www.cancer.gov/?swKeyword=achoo                |
+			| page.name                                | www.cancer.gov/								                |
 			| page.title                               | NCI Search Results                             |
 			| page.metaTitle                           | NCI Search Results - National Cancer Institute |
 			| page.language                            | english                                        |

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -137,7 +137,7 @@ const Home = () => {
 				metaTitle: `${title} - ${siteName}`,
 				name: `${canonicalHost.replace('https://', '')}${
 					window.location.pathname
-				}${window.location.search}`,
+				}`,
 				numberResults: searchResults?.payload?.totalResults || 0,
 				pageNum: current || 1,
 				itemsPerPage: pageunit || 20,


### PR DESCRIPTION
Closes #65

* Removed querystring from `page.name` for tracking event
* Removed querystring from feature files for `page.name` attribute