### PR TITLE
Reduce number of network calls on search results pages

### DIFF
--- a/src/services/api/actions/__tests__/getDictionaryResults.test.js
+++ b/src/services/api/actions/__tests__/getDictionaryResults.test.js
@@ -6,7 +6,7 @@ describe('getDictionaryResults action', () => {
 	const dictionaryName = 'Cancer.gov';
 	setDictionaryEndpoint('/glossary/v1/', dictionaryAudience, dictionaryName);
 
-	const queryString = '?matchType=Exact&size=100&includeAdditionalInfo=true';
+	const queryString = '?matchType=Exact&size=1&includeAdditionalInfo=true';
 
 	test(`should match getDictionaryResults action for keyword "cancer" and language default "English"`, () => {
 		const keyword = 'cancer';

--- a/src/services/api/actions/getDictionaryResults.js
+++ b/src/services/api/actions/getDictionaryResults.js
@@ -3,7 +3,7 @@ import { getEndpoint } from '../endpoints';
 export const getDictionaryResults = ({ keyword, lang = 'en' }) => {
 	const endpoint = getEndpoint('dictionaryResults');
 	const queryString =
-		'?matchType=Exact&size=100&includeAdditionalInfo=true';
+		'?matchType=Exact&size=1&includeAdditionalInfo=true';
 	return {
 		method: 'GET',
 		endpoint: `${endpoint}/${lang}/${encodeURIComponent(

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -45,14 +45,13 @@ const Home = () => {
 	const isFirstPage = !urlQuery.get('page') || urlQuery.get('page') === '1';
 
 	const showBestBet =
-		isBestBetsConfigured && stateBestBetResult?.length > 0 && isFirstPage;
+    isBestBetsConfigured && stateBestBetResult?.length > 0;
+    
 	// Only display Definition component if isDictionaryConfigured is true
 	// and no results returned
-	// and doesn't exist in url or it exists and is the first page
 	const showDefinition =
 		isDictionaryConfigured &&
-		stateDefinitionResult?.results?.length > 0 &&
-		isFirstPage;
+		stateDefinitionResult?.results?.length > 0
 
 	const tracking = useTracking();
 	// Fetch dictionary results only when

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -60,16 +60,19 @@ const Home = () => {
 	// and keyword is provided
 	const dictionaryResults = useCustomQuery(
 		getDictionaryResults({ keyword, lang: language }),
-		isDictionaryConfigured && !!keyword
-	);
+		isDictionaryConfigured && !!keyword && isFirstPage
+  );
+  
 	const searchResults = useCustomQuery(
 		getSearchResults({ language, keyword, currentPage, unit }),
 		!!keyword
-	);
+  );
+  
 	const bestBetResults = useCustomQuery(
 		getBestBetResults({ keyword }),
-		isBestBetsConfigured && !!keyword
-	);
+		isBestBetsConfigured && !!keyword && isFirstPage
+  );
+  
 	// Set hasResults should there be results returned for any search
 	// when a keyword has been provided
 	const hasResults =
@@ -85,14 +88,6 @@ const Home = () => {
 			return;
 		}
 
-		// If no glossaryEndpoint was provided, set setDictionaryResultsLoaded to true
-		if (!isDictionaryConfigured) {
-			setDictionaryResultsLoaded(true);
-		} else if (!dictionaryResults.loading && dictionaryResults.payload) {
-			setStateDefinitionResult(dictionaryResults.payload);
-			setDictionaryResultsLoaded(true);
-		}
-
 		if (!searchResults.loading && searchResults.payload) {
 			const newResults = {
 				...searchResults.payload,
@@ -102,9 +97,17 @@ const Home = () => {
 			setSearchResultsLoaded(true);
 		}
 
+		// If no glossaryEndpoint was provided, set setDictionaryResultsLoaded to true
+		if (!isDictionaryConfigured) {
+			setDictionaryResultsLoaded(true);
+		} else if (!dictionaryResults.loading) {
+			setStateDefinitionResult(dictionaryResults.payload);
+			setDictionaryResultsLoaded(true);
+		}
+
 		if (!isBestBetsConfigured) {
 			setBestBetResultsLoaded(true);
-		} else if (!bestBetResults.loading && bestBetResults.payload) {
+		} else if (!bestBetResults.loading) {
 			setStateBestBetResult(bestBetResults.payload);
 			setBestBetResultsLoaded(true);
 		}
@@ -115,16 +118,13 @@ const Home = () => {
 			searchResultsLoaded
 		) {
 			setDoneLoading(true);
-		}
+		} 
 	}, [
-		bestBetResultsLoaded,
-		bestBetResults.loading,
-		bestBetResults.payload,
-		dictionaryResultsLoaded,
-		dictionaryResults.loading,
-		dictionaryResults.payload,
+    bestBetResultsLoaded,
+    bestBetResults.payload,
+    dictionaryResultsLoaded,
+    dictionaryResults.payload,
 		searchResultsLoaded,
-		searchResults.loading,
 		searchResults.payload,
 	]);
 
@@ -165,17 +165,19 @@ const Home = () => {
 			{doneLoading && hasResults ? (
 				<div className="results">
 					<h3>{`${i18n.resultsFor[language]}: ${keyword}`}</h3>
-					<div
-						className={
-							showBestBet && showDefinition
-								? 'results__feature--bestbet--definition'
-								: 'results__feature'
-						}>
-						{showBestBet && (
-							<BestBet language={language} results={stateBestBetResult} />
-						)}
-						{showDefinition && <Definition {...stateDefinitionResult} />}
-					</div>
+					{isFirstPage && (
+						<div
+							className={
+								showBestBet && showDefinition
+									? 'results__feature--bestbet--definition'
+									: 'results__feature'
+							}>
+							{showBestBet && (
+								<BestBet language={language} results={stateBestBetResult} />
+							)}
+							{showDefinition && <Definition {...stateDefinitionResult} />}
+						</div>
+					)}
 					<SearchResultsList
 						keyword={keyword}
 						language={language}

--- a/support/mock-data/Search/cgov/en/all/metastasis_0-20.json
+++ b/support/mock-data/Search/cgov/en/all/metastasis_0-20.json
@@ -1,0 +1,125 @@
+{
+	"results": [
+		{
+			"title": "Metastatic Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/metastatic-cancer",
+			"contentType": "cgvArticle",
+			"description": "Metastatic cancer is cancer that spreads from its site of origin to another part of the body. Learn how cancer spreads, possible symptoms, common sites where cancer spreads, and how to find out about treatment options."
+		},
+		{
+			"title": "Overcoming the Challenges of Metastatic Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2017/metastatic-cancer-kaplan",
+			"contentType": "cgvBlogPost",
+			"description": "NCI’s Dr. Rosandra Kaplan discusses metastatic cancer research and new ideas for treating and preventing metastatic cancer."
+		},
+		{
+			"title": "DCB - Tumor Metastasis Research - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/organization/dcb/research-portfolio/tumor-metastasis",
+			"contentType": "cgvArticle",
+			"description": "Tumor metastasis research examines the mechanisms that allow cancer cells to leave the primary tumor and spread to another part of the body. Learn about recent tumor metastasis research studies supported by the Division of Cancer Biology."
+		},
+		{
+			"title": "Metastatic Cancer Research - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/metastatic-cancer/research",
+			"contentType": "cgvCancerResearch",
+			"description": "Find research articles about metastatic cancer, which may include news stories, clinical trials, blog posts, and descriptions of active studies."
+		},
+		{
+			"title": "Tumor Exosomes and Metastasis - National Cancer Institute",
+			"url": "https://www.cancer.gov/research/areas/biology/david-lyden-exosomes-metastasis",
+			"contentType": "cgvArticle",
+			"description": "Learn how NCI support is helping researcher David Lyden understand how cancer cell exosomes create a nurturing environment for the growth of metastatic tumors."
+		},
+		{
+			"title": "Sorafenib for Metastatic Thyroid Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/thyroid/research/sorafenib",
+			"contentType": "cgvArticle",
+			"description": "A summary of results from an international phase III trial that compared sorafenib (Nexavar®) and a placebo for the treatment of locally advanced or metastatic differentiated thyroid cancer that is no longer responding to treatment with radioactive iodine"
+		},
+		{
+			"title": "Treatments Expanding for Metastatic Prostate Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2019/enzalutamide-apalutamide-metastatic-prostate-cancer",
+			"contentType": "cgvBlogPost",
+			"description": "Enzalutamide (Xtandi) and apalutamide (Erleada), respectively, improved the survival of men with hormone-sensitive metastatic prostate cancer, in two large trials."
+		},
+		{
+			"title": "TAS-102 for Metastatic Colorectal Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/colorectal/research/tas-102-overall-survival",
+			"contentType": "cgvArticle",
+			"description": "A summary of results from an international phase III trial that compared TAS-102 with placebo in patients with metastatic colorectal cancer whose disease progressed following prior treatment."
+		},
+		{
+			"title": "Targeted Therapies, Tooth Extraction, and Metastasis - National Cancer Institute",
+			"url": "https://www.cancer.gov/research/key-initiatives/ras/ras-central/blog/2015/obenauf-rosen-massague",
+			"contentType": "cgvBlogPost",
+			"description": "Resistance often develops to targeted cancer drugs. Mouse studies indicate that dying cancer cells secrete signals that help other cancer cells survive."
+		},
+		{
+			"title": "Mutations in 10,000 Patients with Metastatic Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2017/mutations-metastatic-cancer",
+			"contentType": "cgvBlogPost",
+			"description": "Researchers have reported the results of an initiative to characterize the genetic mutations in tumors from more than 10,000 patients with advanced cancer treated at the center."
+		},
+		{
+			"title": "Experimental Drug Metarrestin Targets Metastatic Tumors - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2018/metaresstin-metastatic-tumors",
+			"contentType": "cgvBlogPost",
+			"description": "An experimental drug called metarrestin appears to selectively target tumors that have spread to other parts of the body. As this Cancer Currents blog post reports, the drug shrank metastatic tumors and extended survival in in mouse models of pancreatic cancer."
+		},
+		{
+			"title": "Immune-Cell Traps May Aid Cancer Metastasis - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2016/nets-metastasis",
+			"contentType": "cgvBlogPost",
+			"description": "A Cancer Currents blog post on a new study that suggests cancer cells may exploit a normal function of neutrophils, a type of immune cell, to help form metastatic tumors."
+		},
+		{
+			"title": "High-Fat Diet Linked to Prostate Cancer Metastasis - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2018/high-fat-diet-prostate-metastasis",
+			"contentType": "cgvBlogPost",
+			"description": "A new study in mice has revealed a molecular link between a high-fat diet and the growth and spread of prostate cancer. As this Cancer Currents post explains, researchers also showed that an anti-obesity drug that targets a protein that controls fat synthesis could potentially be used to treat metastatic prostate cance"
+		},
+		{
+			"title": "An Organotypic Model Recapitulating Colon Cancer Microenvironment and Metastasis - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-nci/organization/dcb/research-programs/tec/colon-cancer-microenvironment",
+			"contentType": "cgvArticle",
+			"description": "In this study, researchers will engineer three models to examine the microenvironment in both the primary site and metastatic sites of colon cancer."
+		},
+		{
+			"title": "Stem Cells Deliver Chemo to Metastatic Breast Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2017/breast-metastases-targeting-stem-cells",
+			"contentType": "cgvBlogPost",
+			"description": "Using modified stem cells, researchers delivered a cancer drug selectively to metastatic breast cancer tumors in mice, as this NCI Cancer Currents post explains."
+		},
+		{
+			"title": "Metastatic Colorectal Cancer May Spread Early - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2019/early-metastasis-colorectal-cancer",
+			"contentType": "cgvBlogPost",
+			"description": "A new study finds that many colorectal cancers likely have spread long before the original tumor is detected and suggests a need for very early detection."
+		},
+		{
+			"title": "Nab-Paclitaxel Plus Gemcitabine for Metastatic Pancreatic Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/pancreatic/research/nab-paclitaxel-gemcitabine",
+			"contentType": "cgvArticle",
+			"description": "A summary of results from a phase III trial that compared the combination of albumin-bound paclitaxel (nab-paclitaxel [Abraxane®]) and gemcitabine (Gemzar®) versus gemcitabine alone in patients with metastatic pancreatic cancer."
+		},
+		{
+			"title": "Abiraterone Improves Survival in Metastatic Prostate Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/prostate/research/abiraterone",
+			"contentType": "cgvArticle",
+			"description": "A multinational phase III trial found that the drug abiraterone acetate prolonged the median survival of patients with metastatic castration-resistant prostate cancer by 4 months compared with patients who received a placebo."
+		},
+		{
+			"title": "FDA Approves Ribociclib, Palbociclib for Metastatic Breast Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2017/fda-ribociclib-palbociclib-breast-cancer",
+			"contentType": "cgvBlogPost",
+			"description": "A Cancer Currents blog on the FDA’s approval of two targeted therapies, ribociclib and palbociclib, for women with metastatic breast cancer."
+		},
+		{
+			"title": "Eribulin Improves Survival of Women with Metastatic Breast Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/breast/research/eribulin-improves-survival",
+			"contentType": "cgvArticle",
+			"description": "Treatment with eribulin (Halaven™) improved overall survival in women with metastatic breast cancer whose disease progressed despite multiple rounds of prior chemotherapy, according to the results of a phase III clinical trial called EMBRACE."
+		}
+	],
+	"totalResults": 5826
+}

--- a/support/mock-data/Search/cgov/en/all/metastasis_20-20.json
+++ b/support/mock-data/Search/cgov/en/all/metastasis_20-20.json
@@ -1,0 +1,125 @@
+{
+	"results": [
+		{
+			"title": "Enzalutamide Improves Survival in Patients with Metastatic Prostate Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/prostate/research/enzalutamide-metastatic",
+			"contentType": "cgvArticle",
+			"description": "A summary of results from an international phase III trial that compared enzalutamide (Xtandi®) and placebo for the treatment of metastatic prostate cancer that had progressed during treatment with androgen deprivation therapy."
+		},
+		{
+			"title": "Low vitamin D linked to breast cancer metastasis - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2016/vitamin-d-metastasis",
+			"contentType": "cgvBlogPost",
+			"description": "Low vitamin D levels are associated with metastasis in women with breast cancer, suggests a new study."
+		},
+		{
+			"title": "Tracking Treatment Resistance in Metastatic Breast Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2017/metastatic-breast-cancer-treatment-resistance-evolution",
+			"contentType": "cgvBlogPost",
+			"description": "In women with metastatic breast cancer that is resistant to available treatments, a new study suggests that their tumors may have common vulnerabilities."
+		},
+		{
+			"title": "Combining Targeted Drugs Effective for Metastatic Breast Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/breast/research/two-drugs-one-target",
+			"contentType": "cgvArticle",
+			"description": "Combining two drugs that target the HER2 protein, trastuzumab (Herceptin®) and pertuzumab, with chemotherapy may be a new treatment option for women with HER2-positive metastatic breast cancer."
+		},
+		{
+			"title": "Nivolumab for Metastatic Melanoma without a BRAF Mutation - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/skin/research/nivolumab",
+			"contentType": "cgvArticle",
+			"description": "A summary of results from an international phase III trial show that nivolumab (Opdivo®) improves overall survival compared with the chemotherapy drug dacarbazine in patients with metastatic melanoma whose tumors do not have a mutation in the BRAF gene."
+		},
+		{
+			"title": "FDA Approves T-VEC to Treat Metastatic Melanoma - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2015/t-vec-melanoma",
+			"contentType": "cgvBlogPost",
+			"description": "The FDA has approved the first oncolytic virus therapy, talimogene laherparepvec (T-VEC). The drug was approved for the treatment of metastatic melanoma that cannot be removed surgically."
+		},
+		{
+			"title": "Hormone Therapy Plus Chemotherapy for Metastatic Prostate Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/prostate/research/chemohormonal-treatment-extends-survival",
+			"contentType": "cgvArticle",
+			"description": "A trial of androgen deprivation therapy (ADT) plus six cycles of docetaxel versus ADT alone found that after a median follow-up of nearly 29 months, median overall survival was 13.6 months longer with the combination therapy than with ADT alone."
+		},
+		{
+			"title": "Clinical Trials to Treat Adult Metastatic Brain Tumors - National Cancer Institute",
+			"url": "https://www.cancer.gov/about-cancer/treatment/clinical-trials/adult-metastatic-brain-tumors",
+			"contentType": "nciAppModulePage",
+			"description": "Find clinical trials to treat adult metastatic brain tumors."
+		},
+		{
+			"title": "Ribociclib as First-Line Treatment for Metastatic Breast Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/breast/research/ribociclib-metastatic-breast",
+			"contentType": "cgvArticle",
+			"description": "A summary of interim results from a phase III trial testing ribociclib plus letrozole (Femara®) as a first-line treatment for postmenopausal women with hormone receptor-positive, HER2-negative metastatic breast cancer."
+		},
+		{
+			"title": "Nanoparticle generator targets metastatic breast cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2016/nanoparticle-generator-metastases",
+			"contentType": "cgvBlogPost",
+			"description": "Researchers have developed a new injectable nanoparticle-generating technology that can deliver a cancer drug to the nucleus of metastatic breast cancer cells."
+		},
+		{
+			"title": "New Treatments Emerge for Metastatic HER2+ Breast Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2020/tucatinib-trastuzumab-deruxtecan-her2-positive-metastatic-breast-cancer",
+			"contentType": "cgvBlogPost",
+			"description": "Tucatinib improved survival for women in the HER2CLIMB trial, including some whose cancer had spread to the brain. Trastuzumab deruxtecan improved survival and shrank many tumors in the DESTINY-Breast01 trial, which led to its accelerated approval by FDA."
+		},
+		{
+			"title": "Sacituzumab Govitecan for Metastatic Triple-Negative Breast Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2020/fda-sacituzumab-govitecan-triple-negative-breast-cancer",
+			"contentType": "cgvBlogPost",
+			"description": "FDA has approved the targeted therapy sacituzumab govitecan (Trodelvy) for the treatment of triple-negative breast cancer that has spread to other parts of the body. Under the approval, patients must have already undergone at least two prior treatment regimens."
+		},
+		{
+			"title": "Immunotherapy targets metastatic breast cancer–cell mutations - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/press-releases/2018/immunotherapy-targets-breast-cancer-case-report",
+			"contentType": "cgvPressRelease",
+			"description": "A novel approach to immunotherapy developed by NCI researchers led to the complete regression of breast cancer in a patient who was unresponsive to all other treatments. The findings were published in Nature Medicine."
+		},
+		{
+			"title": "Metastatic Squamous Neck Cancer with Occult Primary Treatment (Adult) (PDQ®)–Patient Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/head-and-neck/patient/adult/metastatic-squamous-neck-treatment-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Metastatic squamous neck cancer with occult primary (unknown primary) treatment options include surgery, radiation therapy, or a combination of both. Learn more about the diagnosis and treatment of these tumors in this expert-reviewed summary."
+		},
+		{
+			"title": "Metastatic Squamous Neck Cancer With Occult Primary Treatment (Adult) (PDQ®)–Health Professional Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/head-and-neck/hp/adult/metastatic-squamous-neck-treatment-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Metastatic squamous neck cancer with occult primary treatment options include surgery, radiation therapy or a combination of both. Get detailed information about newly diagnosed or recurrent metastatic squamous neck cancer in this summary for clinicians."
+		},
+		{
+			"title": "Some Brain Cells May Help to Fuel Cancer Metastasis - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/cancer-currents-blog/2019/brain-metastasis-astrocytes-ppar-gamma",
+			"contentType": "cgvBlogPost",
+			"description": "Brain cells called astrocytes can activate PPAR-gamma, a growth protein in cancer cells that helps them gain a foothold in the brain, a new study shows. The findings suggest that drugs that block PPAR-gamma activity may help treat brain metastases."
+		},
+		{
+			"title": "Study estimates number of U.S. women living with metastatic breast cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/news-events/press-releases/2017/metastatic-breast-cancer-survival-rates",
+			"contentType": "cgvPressRelease",
+			"description": "A new study shows that the number of women in the United States living with distant metastatic breast cancer (MBC), the most severe form of the disease, is growing. This is likely due to the aging of the U.S. population and improvements in treatment."
+		},
+		{
+			"title": "Cetuximab Plus Oxaliplatin May Not Be Effective Primary Treatment for Metastatic Colorectal Cancer - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/colorectal/research/cetuximab-chemo-no-benefit",
+			"contentType": "cgvArticle",
+			"description": "In a randomized phase III trial, the addition of the targeted therapy cetuximab to oxaliplatin and fluoropyrimidine chemotherapy did not prolong survival or time to disease progression of patients with advanced colorectal cancer."
+		},
+		{
+			"title": "Transitional Cell Cancer of the Renal Pelvis and Ureter Treatment (PDQ®)–Health Professional Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/kidney/hp/transitional-cell-treatment-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Transitional cell cancer of the renal pelvis and ureter treatment is primarily surgery. In metastatic or recurrent disease, chemotherapy regimens for metastatic bladder cancer are often used. Get detailed treatment information for newly diagnosed and recurrent disease in this clinician summary."
+		},
+		{
+			"title": "Gallbladder Cancer Treatment (PDQ®)–Health Professional Version - National Cancer Institute",
+			"url": "https://www.cancer.gov/types/gallbladder/hp/gallbladder-treatment-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Gallbladder cancer treatment for cancer found during routine gallbladder surgery is often surgery alone. Unresectable, recurrent or metastatic gallbladder cancer treatment options include relief of biliary obstruction, radiation, and chemotherapy. Get more information in this clinician summary."
+		}
+	],
+	"totalResults": 5826
+}

--- a/support/mock-data/Search/cgov/es/all/cáncer de mama_0-20.json
+++ b/support/mock-data/Search/cgov/es/all/cáncer de mama_0-20.json
@@ -1,0 +1,125 @@
+{
+	"results": [
+		{
+			"title": "Prevención del cáncer de seno (mama) (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/paciente/prevencion-seno-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Sumario de información revisada por expertos sobre factores que influyen en el riesgo de presentar cáncer de mama y sobre las investigaciones dirigidas a la prevención de esta enfermedad."
+		},
+		{
+			"title": "Tratamiento del cáncer de seno (mama) durante el embarazo (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/paciente/tratamiento-seno-embarazo-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del tratamiento de cáncer de seno (mama) durante el embarazo."
+		},
+		{
+			"title": "Tratamiento del cáncer de seno (mama) infantil (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/paciente/tratamiento-seno-infantil-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "La mayoría de las masas en las mamas de los niños no son cáncer. Cuando el cáncer de mama se presenta en  niños, las opciones de tratamiento incluyen cirugía y radioterapia. Para obtener más información sobre los factores de riesgo, los síntomas, las  pruebas diagnósticas y el tratamiento del cáncer de mama infantil consulte este resumen de información revisada por expertos."
+		},
+		{
+			"title": "Tratamiento del cáncer de seno (mama) masculino (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/paciente/tratamiento-seno-masculino-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del tratamiento del  cáncer de seno (mama) masculino."
+		},
+		{
+			"title": "Tratamiento del cáncer de seno (mama) en adultas (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/paciente/tratamiento-seno-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del tratamiento del cáncer de seno (mama) en adultas."
+		},
+		{
+			"title": "Exámenes de detección del cáncer de seno (mama) (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/paciente/deteccion-seno-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Sumario de información revisada por expertos sobre exámenes que se usan para detectar el cáncer de mama."
+		},
+		{
+			"title": "Tratamiento del cáncer de seno (mama) masculino (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/pro/tratamiento-seno-masculino-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del tratamiento del  cáncer de seno (mama) masculino."
+		},
+		{
+			"title": "Prevención del cáncer de seno (mama) (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/pro/prevencion-seno-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Sumario de información revisada por expertos sobre factores que influyen en el riesgo de presentar cáncer de mama y sobre las investigaciones dirigidas a la prevención de esta enfermedad."
+		},
+		{
+			"title": "Cáncer de seno (mama)—Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno",
+			"contentType": "cgvCancerTypeHome",
+			"description": "En las mujeres, el cáncer de mama es el segundo tipo de cáncer más común, seguido por el cáncer de piel. Las mamografías pueden detectar el cáncer de mama temprano. Comience aquí su búsqueda de información sobre tratamiento, causas y prevención, investigación y estadísticas relacionados con el cáncer de mama."
+		},
+		{
+			"title": "Tratamiento del cáncer de seno (mama) durante el embarazo (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/pro/tratamiento-seno-embarazo-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del tratamiento del  cáncer de seno (mama) durante el embarazo."
+		},
+		{
+			"title": "Cáncer de seno (mama)—Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/pro",
+			"contentType": "cgvCancerTypeHome",
+			"description": "El tipo más común de cáncer de mama es el carcinoma ductal, que empieza en las células de los conductos. El cáncer de mama a veces se forma en células de los lóbulos y otros tejidos de la mama. Encuentre información basada en datos probatorios sobre tratamiento, causas, prevención, investigación y estadísticas."
+		},
+		{
+			"title": "Exámenes de detección del cáncer de seno (mama) (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/pro/deteccion-seno-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Sumario de información revisada por expertos sobre pruebas que se usan para detectar el cáncer de mama."
+		},
+		{
+			"title": "Investigación sobre el cáncer de seno (mama) - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/investigacion",
+			"contentType": "cgvCancerResearch",
+			"description": "Encuentre artículos de investigación sobre el cáncer de seno (mama), que pueden incluir noticias, estudios clínicos, artículos de blogs y descripciones de estudios activos."
+		},
+		{
+			"title": "Tratamiento del cáncer de seno (mama) infantil (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/pro/tratamiento-seno-infantil-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos y con base en datos probatorios acerca de la incidencia, los resultados, los factores de riesgo y el tratamiento del fibroadenoma y el cáncer de mama infantiles."
+		},
+		{
+			"title": "Tratamiento del cáncer de seno (mama) en adultas (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/pro/tratamiento-seno-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del tratamiento del cáncer de seno (mama) en adultas."
+		},
+		{
+			"title": "Cáncer inflamatorio de seno (mama) - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/hoja-informativa-seno-inflamatorio",
+			"contentType": "cgvArticle",
+			"description": "Hoja informativa sobre el diagnóstico y tratamiento de un tipo poco común de cáncer de seno en el que el seno se presenta enrojecido, hinchado y caliente."
+		},
+		{
+			"title": "El ejercicio y la supervivencia en las mujeres con cáncer de seno (mama) - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/noticias/temas-y-relatos-blog/2020/cancer-seno-ejercicio-supervivencia",
+			"contentType": "cgvBlogPost",
+			"description": "Los resultados de un estudio reciente demostraron que las mujeres con cáncer de seno (mama) de riesgo alto de recidiva que hacían ejercicio con regularidad antes del diagnóstico de cáncer y después del tratamiento tuvieron menos probabilidad de que el cáncer volviera o de que murieran en comparación con mujeres inactivas."
+		},
+		{
+			"title": "Abemaciclib obtiene nueva aprobación para cáncer de seno (mama) - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/noticias/temas-y-relatos-blog/2018/abemaciclib-fda-cancer-seno-primera-linea",
+			"contentType": "cgvBlogPost",
+			"description": "La FDA ha aprobado el inhibidor de CDK4/6 abemaciclib (Verzenio) como tratamiento de primera línea en algunas mujeres con cáncer avanzado o metastático de seno (mama). De acuerdo a esta aprobación, el fármaco debe ser usado en combinación con un inhibidor de aromatasa, el artículo del blog Temas y Relatos explica."
+		},
+		{
+			"title": "Uso del sacituzumab govitecán para tratar el cáncer de seno (mama) metastásico triple negativo - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/noticias/temas-y-relatos-blog/2020/fda-sacituzumab-govitecan-cancer-seno-triple-negativo",
+			"contentType": "cgvBlogPost",
+			"description": "La FDA aprobó una terapia dirigida, el sacituzumab govitecán (Trodelvy), para tratar el cáncer de seno (mama) triple negativo que se diseminó a otras partes del cuerpo. El medicamento se aprobó para el uso en pacientes que ya recibieron al menos dos regímenes de tratamiento anteriores."
+		},
+		{
+			"title": "Un nuevo fármaco puede ser una opción de tratamiento para algunos cánceres de mama - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/seno/investigacion/t-dm1",
+			"contentType": "cgvArticle",
+			"description": "Los resultados de un estudio clínico internacional permiten suponer que, en poco tiempo, habrá otra opción de tratamiento para las mujeres con cáncer de mama metastásico HER2 positivo que deja de responder a los tratamientos dirigidos con trastuzumab."
+		}
+	],
+	"totalResults": 1339
+}

--- a/support/mock-data/Search/cgov/es/all/cáncer de mama_20-20.json
+++ b/support/mock-data/Search/cgov/es/all/cáncer de mama_20-20.json
@@ -1,0 +1,125 @@
+{
+	"results": [
+		{
+			"title": "Aspectos generales de la prevención del cáncer (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/causas-prevencion/aspectos-generales-prevencion-paciente-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Información general sobre la prevención del cáncer y descripciones de conceptos usados en sumarios específicos sobre la prevención del cáncer."
+		},
+		{
+			"title": "Linfedema (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/efectos-secundarios/linfedema/linfedema-pro-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos sobre la anatomía, la patofisiología, las manifestaciones clínicas, el diagnóstico y el tratamiento del linfedema relacionado con el cáncer, una afección en la que se acumula líquido linfático en los tejidos y causa inflamación.."
+		},
+		{
+			"title": "Sofocos y sudores nocturnos (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/efectos-secundarios/sexualidad-mujeres/sofocos-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca de las causas y el tratamiento de  los sofocos y sudores nocturnos en los pacientes de cáncer."
+		},
+		{
+			"title": "Comunicación en la atención del cáncer (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/sobrellevar/adaptacion-al-cancer/comunicacion-pro-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos sobre la comunicación con el paciente de cáncer y su familia, incluso los aspectos distintivos de la comunicación con pacientes de cáncer, los factores que afectan la comunicación y el entrenamiento de las aptitudes para la comunicación."
+		},
+		{
+			"title": "Acupuntura (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/mca/paciente/acupuntura-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos sobre la acupuntura como tratamiento para las personas con cáncer o trastornos relacionados con esta enfermedad."
+		},
+		{
+			"title": "Toxicidad financiera del tratamiento del cáncer (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/manejo-del-cancer/costos/toxicidad-financiera-pro-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del riesgo de sufrir dificultades financieras durante el tratamiento del cáncer."
+		},
+		{
+			"title": "Linfedema (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/efectos-secundarios/linfedema/linfedema-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del tratamiento del linfedema."
+		},
+		{
+			"title": "Adaptación al cáncer: ansiedad y sufrimiento (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/sobrellevar/sentimientos/ansiedad-sufrimiento-pro-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca de las difíciles respuestas emocionales que se presentan en muchos de los pacientes con cáncer.  Este sumario se enfoca en asuntos de la adaptación normal, alteración psicosocial y trastornos de adaptación."
+		},
+		{
+			"title": "Tratamiento de los cánceres raros en la niñez (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/tipos/infantil/paciente/canceres-infantiles-raros-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del tratamiento de los cánceres raros en la niñez  como los cánceres de la cabeza y el cuello, el tórax, el abdomen, el aparato reproductor, la piel y otros."
+		},
+		{
+			"title": "Aspectos generales de la prevención del cáncer (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/causas-prevencion/aspectos-generales-prevencion-pro-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Información general sobre la prevención del cáncer y  descripciones de conceptos usados en sumarios específicos sobre la prevención del cáncer."
+		},
+		{
+			"title": "Antineoplastones (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/mca/pro/antineoplastones-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos sobre los antineoplastones como tratamiento para personas con cáncer."
+		},
+		{
+			"title": "Sofocos y sudores nocturnos (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/efectos-secundarios/sexualidad-mujeres/sofocos-pro-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca de las causas y el tratamiento de los sofocos y sudores nocturnos en los pacientes de cáncer."
+		},
+		{
+			"title": "Aspectos generales de los exámenes de detección del cáncer (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/deteccion/aspectos-generales-deteccion-pro-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Información sobre la medición de la eficacia de los exámenes de detección del cáncer y la evaluación de la solidez de los datos  probatorios obtenidos en estudios de investigación sobre la detección del cáncer."
+		},
+		{
+			"title": "Acupuntura (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/mca/pro/acupuntura-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos sobre la acupuntura como tratamiento para las personas con cáncer o trastornos relacionados con esta enfermedad."
+		},
+		{
+			"title": "Aspectos generales de los exámenes de detección del cáncer (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/deteccion/aspectos-generales-deteccion-paciente-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Información sobre la medición de la eficacia de los exámenes de detección del cáncer y la evaluación de la solidez de las pruebas obtenidas en estudios de investigación de detección del cáncer."
+		},
+		{
+			"title": "Deterioro cognitivo en adultos con cánceres fuera del sistema nervioso central (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/efectos-secundarios/memoria/deterioro-cognitivo-pro-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del deterioro cognitivo en pacientes de cáncer versus la cognición normal, e intervenciones para tratar los cambios cognitivos"
+		},
+		{
+			"title": "Fatiga (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/efectos-secundarios/fatiga/fatiga-pro-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca de la fatiga, una afección caracterizada por extremo cansancio e incapacidad para funcionar por la falta de energía, que a menudo se observa como una complicación del cáncer y su tratamiento."
+		},
+		{
+			"title": "Comunicación en la atención del cáncer (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/sobrellevar/adaptacion-al-cancer/comunicacion-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de la información revisada por expertos acerca de la comunicación con el paciente de cáncer y sus familiares, que incluye los aspectos distintivos de la comunicación con pacientes de cáncer, los factores que afectan la comunicación y la capacitación en aptitudes para la comunicación."
+		},
+		{
+			"title": "Toxicidad financiera del tratamiento del cáncer (PDQ®)–Versión para pacientes - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/manejo-del-cancer/costos/toxicidad-financiera-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos acerca del riesgo de sufrir dificultades financieras durante el tratamiento del cáncer."
+		},
+		{
+			"title": "Coenzima Q10 (PDQ®)–Versión para profesionales de salud - Instituto Nacional del Cáncer",
+			"url": "https://www.cancer.gov/espanol/cancer/tratamiento/mca/pro/coenzima-q10-pdq",
+			"contentType": "pdqCancerInfoSummary",
+			"description": "Resumen de información revisada por expertos sobre el uso de la coenzima Q10 como tratamiento para las personas con cáncer."
+		}
+	],
+	"totalResults": 1339
+}


### PR DESCRIPTION
This is intended to reduce the number of unnecessary network calls for best bets and Definition on subsequent pages.

Adding the isFirstPage gate will limit fetches for BestBets and Definition to the first page of results and prevent calls on subsequent or deep linked results pages.

https://react-app-dev.cancer.gov/sitewide-search-app/pr-87/?swkeyword=tumor&page=2&pageunit=20