### PR TITLE
(#88) increase contrast for best bets link

### DIFF
--- a/src/components/molecules/best-bet/best-bet.scss
+++ b/src/components/molecules/best-bet/best-bet.scss
@@ -18,8 +18,12 @@ definition + .best-bet {
 		.list-item {
 			margin-bottom: 0;
 
-			.title {
+			.title-and-desc > * {
 				font-size: 1em;
+      }
+      
+			a.title {
+				color: #276998;
 			}
 		}
 	}


### PR DESCRIPTION
Closes #88 .

Contrast increased to satisfy WCAG AA (#2B7BBA -> #276998.

Looking at BB structure there is actually 2 .title landmarks so needed to change the target css accordingly.

<img width="1330" alt="Screen Shot 2020-08-14 at 10 56 21 AM" src="https://user-images.githubusercontent.com/45469809/90262834-d3acf700-de1c-11ea-9a18-c65f0423a486.png">


