### PR TITLE
(#129) Publish main.css as a main-legacy.css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
 				"postcss-flexbugs-fixes": "4.1.0",
 				"postcss-loader": "3.0.0",
 				"postcss-normalize": "8.0.1",
+				"postcss-prefix-selector": "^1.16.0",
 				"postcss-preset-env": "6.7.0",
 				"postcss-safe-parser": "4.0.1",
 				"prettier": "^2.2.1",
@@ -23150,6 +23151,15 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/postcss-prefix-selector": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
+			"integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
+			"dev": true,
+			"peerDependencies": {
+				"postcss": ">4 <9"
 			}
 		},
 		"node_modules/postcss-preset-env": {
@@ -48565,6 +48575,12 @@
 				"postcss": "^7.0.2",
 				"postcss-values-parser": "^2.0.0"
 			}
+		},
+		"postcss-prefix-selector": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
+			"integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
+			"dev": true
 		},
 		"postcss-preset-env": {
 			"version": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
 	},
 	"scripts": {
 		"start": "node scripts/start.js",
-		"build": "node scripts/build.js",
+		"build:cgdp-legacy": "node scripts/generate-cgdp-legacy.js",
+		"build:cra": "node scripts/build.js",
+		"build": "npm run build:cra && npm run build:cgdp-legacy",
 		"test": "NODE_ENV=test npm run lint && NODE_ENV=test npm run pa11y-tests && NODE_ENV=test npm run unit-tests && NODE_ENV=test npm run cy:ci",
 		"posttest": "npm run prepare-reports",
 		"test:pa11y": "./node_modules/.bin/pa11y-ci",
@@ -197,6 +199,7 @@
 		"postcss-flexbugs-fixes": "4.1.0",
 		"postcss-loader": "3.0.0",
 		"postcss-normalize": "8.0.1",
+		"postcss-prefix-selector": "^1.16.0",
 		"postcss-preset-env": "6.7.0",
 		"postcss-safe-parser": "4.0.1",
 		"prettier": "^2.2.1",

--- a/scripts/generate-cgdp-legacy.js
+++ b/scripts/generate-cgdp-legacy.js
@@ -1,0 +1,35 @@
+/* -------------------------------------------------------------------------
+ * So we need to prefix all CTS css selectors with .cgdpl to support the
+ * www redesign using ncids. Since our app manages its css with each
+ * component, we can't just create a new entry point. Well, I guess we could
+ * and just build the app twice and then do something, but that seems icky.
+ * ------------------------------------------------------------------------- */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const appPaths = require('../config/paths');
+const postcss = require('postcss');
+const prefixer = require('postcss-prefix-selector');
+
+const inputFileName = path.join(appPaths.appBuild, '/static/css/main.css');
+const outputFileName = path.join(
+	appPaths.appBuild,
+	'/static/css/main-legacy.css'
+);
+
+try {
+	const inputCss = fs.readFileSync(inputFileName, 'utf8');
+
+	const outputCss = postcss()
+		.use(
+			prefixer({
+				prefix: '.cgdpl',
+			})
+		)
+		.process(inputCss).css;
+
+	fs.writeFileSync(outputFileName, outputCss);
+} catch (err) {
+	console.error(err);
+}


### PR DESCRIPTION

* npm install --save-dev postcss-prefix-selector

* Create the script for creating the legacy css. Create this as scripts/generate-cgdp-legacy.js

* Change the "build": "node scripts/build.js"

See: https://github.com/NCIOCPL/cgov-react-app-playground/issues/50

Closes https://github.com/NCIOCPL/sitewide-search-app/issues/129