### PR TITLE
(#154) Limit workflow runs and Implement OCPL Standards Check

### DIFF
--- a/.github/workflows/ocpl_cm_standards_check.yml
+++ b/.github/workflows/ocpl_cm_standards_check.yml
@@ -1,0 +1,9 @@
+name: OCPL Configuration Management Standards Check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+jobs:
+  commitlint_remote:
+    uses: nciocpl/.github/.github/workflows/ocpl_cm_standards_check.yml@workflow/v1

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,17 @@
 name: Workflow
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - main
+      - develop
+      - 'hotfix/**'
+      - 'release/**'
+      - 'feature/**'
+      - 'prototype/**'
+    tags:
+      - '*'
+  pull_request:
 jobs:
   react-app-workflow:
     uses: nciocpl/cgov-react-app-playground/.github/workflows/workflow.yml@workflow/v1


### PR DESCRIPTION
- Limits the build for ticket branches to be only for pull requests
Closes #154