### PR TITLE
(#163) Upgrade loader-utils to version 2.0.4 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3766,9 +3766,9 @@
 			}
 		},
 		"node_modules/@cypress/webpack-preprocessor/node_modules/loader-utils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-			"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 			"dev": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
@@ -7571,9 +7571,9 @@
 			}
 		},
 		"node_modules/adjust-sourcemap-loader/node_modules/loader-utils": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-			"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 			"dev": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
@@ -11462,9 +11462,9 @@
 			}
 		},
 		"node_modules/css-loader/node_modules/loader-utils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-			"integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 			"dev": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
@@ -12426,9 +12426,9 @@
 			"dev": true
 		},
 		"node_modules/decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10"
@@ -13601,9 +13601,9 @@
 			}
 		},
 		"node_modules/eslint-loader/node_modules/loader-utils": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-			"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 			"dev": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
@@ -24142,9 +24142,9 @@
 			"dev": true
 		},
 		"node_modules/json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"bin": {
 				"json5": "lib/cli.js"
@@ -24419,9 +24419,9 @@
 			}
 		},
 		"node_modules/loader-utils": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-			"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+			"integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
 			"dev": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
@@ -24433,9 +24433,9 @@
 			}
 		},
 		"node_modules/loader-utils/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
@@ -25044,9 +25044,9 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin/node_modules/loader-utils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-			"integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 			"dev": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
@@ -28721,9 +28721,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.6"
@@ -28988,9 +28988,9 @@
 			}
 		},
 		"node_modules/react-dev-utils/node_modules/loader-utils": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-			"integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+			"integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
 			"dev": true,
 			"engines": {
 				"node": ">= 12.13.0"
@@ -29714,9 +29714,9 @@
 			"dev": true
 		},
 		"node_modules/resolve-url-loader": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.4.tgz",
-			"integrity": "sha512-D3sQ04o0eeQEySLrcz4DsX3saHfsr8/N6tfhblxgZKXxMT2Louargg12oGNfoTRLV09GXhVUe5/qgA5vdgNigg==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.5.tgz",
+			"integrity": "sha512-mgFMCmrV/tA4738EsFmPFE5/MaqSgUMe8LK971kVEKA/RrNVb7+VqFsg/qmKyythf34eyq476qIobP/gfFBGSQ==",
 			"dev": true,
 			"dependencies": {
 				"adjust-sourcemap-loader": "3.0.0",
@@ -29724,7 +29724,7 @@
 				"compose-function": "3.0.3",
 				"convert-source-map": "1.7.0",
 				"es6-iterator": "2.0.3",
-				"loader-utils": "1.2.3",
+				"loader-utils": "^1.2.3",
 				"postcss": "7.0.36",
 				"rework": "1.0.1",
 				"rework-visit": "1.0.0",
@@ -29732,41 +29732,6 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/resolve-url-loader/node_modules/emojis-list": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-			"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.10"
-			}
-		},
-		"node_modules/resolve-url-loader/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/resolve-url-loader/node_modules/loader-utils": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-			"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-			"dev": true,
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^2.0.0",
-				"json5": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/resolve-url-loader/node_modules/postcss": {
@@ -30043,9 +30008,9 @@
 			}
 		},
 		"node_modules/sass-loader/node_modules/loader-utils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-			"integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+			"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 			"dev": true,
 			"dependencies": {
 				"big.js": "^5.2.2",
@@ -32427,9 +32392,9 @@
 			}
 		},
 		"node_modules/tsconfig-paths/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+			"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
@@ -37478,9 +37443,9 @@
 					}
 				},
 				"loader-utils": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-					"integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+					"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 					"dev": true,
 					"requires": {
 						"big.js": "^5.2.2",
@@ -40527,9 +40492,9 @@
 			},
 			"dependencies": {
 				"loader-utils": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+					"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 					"dev": true,
 					"requires": {
 						"big.js": "^5.2.2",
@@ -43647,9 +43612,9 @@
 			},
 			"dependencies": {
 				"loader-utils": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-					"integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+					"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 					"dev": true,
 					"requires": {
 						"big.js": "^5.2.2",
@@ -44388,9 +44353,9 @@
 			"dev": true
 		},
 		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
 			"dev": true
 		},
 		"dedent": {
@@ -45525,9 +45490,9 @@
 					}
 				},
 				"loader-utils": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-					"integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+					"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 					"dev": true,
 					"requires": {
 						"big.js": "^5.2.2",
@@ -53334,9 +53299,9 @@
 			"dev": true
 		},
 		"json5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-			"integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true
 		},
 		"jsonfile": {
@@ -53545,9 +53510,9 @@
 			"dev": true
 		},
 		"loader-utils": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-			"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+			"integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
 			"dev": true,
 			"requires": {
 				"big.js": "^5.2.2",
@@ -53556,9 +53521,9 @@
 			},
 			"dependencies": {
 				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+					"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"
@@ -54046,9 +54011,9 @@
 			},
 			"dependencies": {
 				"loader-utils": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-					"integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+					"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 					"dev": true,
 					"requires": {
 						"big.js": "^5.2.2",
@@ -57005,9 +56970,9 @@
 			"dev": true
 		},
 		"qs": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+			"integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
 			"dev": true
 		},
 		"querystring": {
@@ -57210,9 +57175,9 @@
 					"dev": true
 				},
 				"loader-utils": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz",
-					"integrity": "sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
+					"integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
 					"dev": true
 				},
 				"locate-path": {
@@ -57773,9 +57738,9 @@
 			"dev": true
 		},
 		"resolve-url-loader": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.4.tgz",
-			"integrity": "sha512-D3sQ04o0eeQEySLrcz4DsX3saHfsr8/N6tfhblxgZKXxMT2Louargg12oGNfoTRLV09GXhVUe5/qgA5vdgNigg==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.5.tgz",
+			"integrity": "sha512-mgFMCmrV/tA4738EsFmPFE5/MaqSgUMe8LK971kVEKA/RrNVb7+VqFsg/qmKyythf34eyq476qIobP/gfFBGSQ==",
 			"dev": true,
 			"requires": {
 				"adjust-sourcemap-loader": "3.0.0",
@@ -57783,39 +57748,13 @@
 				"compose-function": "3.0.3",
 				"convert-source-map": "1.7.0",
 				"es6-iterator": "2.0.3",
-				"loader-utils": "1.2.3",
+				"loader-utils": "^1.2.3",
 				"postcss": "7.0.36",
 				"rework": "1.0.1",
 				"rework-visit": "1.0.0",
 				"source-map": "0.6.1"
 			},
 			"dependencies": {
-				"emojis-list": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-					"integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-					"dev": true
-				},
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-					"integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^2.0.0",
-						"json5": "^1.0.1"
-					}
-				},
 				"postcss": {
 					"version": "7.0.36",
 					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
@@ -58127,9 +58066,9 @@
 			},
 			"dependencies": {
 				"loader-utils": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.3.tgz",
-					"integrity": "sha512-THWqIsn8QRnvLl0shHYVBN9syumU8pYWEHPTmkiVGd+7K5eFNVSY6AJhRvgGF70gg1Dz+l/k8WicvFCxdEs60A==",
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+					"integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
 					"dev": true,
 					"requires": {
 						"big.js": "^5.2.2",
@@ -59941,9 +59880,9 @@
 			},
 			"dependencies": {
 				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+					"integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
 					"dev": true,
 					"requires": {
 						"minimist": "^1.2.0"


### PR DESCRIPTION
* Ran `npm audit fix` to resolve `loader-utils` vulnerability which was part of the critical list items noted in a report generated from `npm audit` command

Closes #163