### PR TITLE
(#220, #223) Add results page search box using shared Autocomplete, Analytics

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Mirror the `min-release-age=7` install cooldown in .npmrc so Dependabot
+    # does not open PRs for versions that cannot yet be installed locally/CI.
+    cooldown:
+      default-days: 7
+    # Internal package: published to GitHub Packages.
+    registries:
+      - npm-github
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ _UpgradeReport_Files/
 # === Rules for release artifacts ===
 /*.tar.*
 /*.pkg
+/*.zip
 /SHASUMS*.txt*
 
 # === Rules for `node_modules` ===

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -98,6 +98,12 @@ module.exports = function (webpackEnv) {
 					? {
 							sassOptions: {
 								includePaths: [path.join(__dirname, '../node_modules/@nciocpl/ncids-css/packages'), path.join(__dirname, '../node_modules/@nciocpl/ncids-css/uswds-packages')],
+								// Quiet build noise: deprecation notices and USWDS compile
+								// warnings (the app already opts out via
+								// `$theme-show-compile-warnings: false`). Errors still surface.
+								quietDeps: true,
+								silenceDeprecations: ['legacy-js-api', 'import', 'mixed-decls'],
+								logger: { warn() {}, debug() {} },
 							},
 					  }
 					: {};

--- a/cypress/e2e/AppAnalytics/SearchBoxSubmit.feature
+++ b/cypress/e2e/AppAnalytics/SearchBoxSubmit.feature
@@ -1,0 +1,17 @@
+Feature: As a user, when I submit a search from the results-page search box an analytics event should be raised so the website owner can gather data on my search behavior. (issue #223)
+
+
+    Scenario: Analytics fires when a user submits an edited search from the results search box
+        Given "resultsPageTitle" is set to "NCI Search Results"
+        And "searchCollection" is set to "cgov"
+        And "language" is set to "en"
+        And "baseHost" is set to "http://localhost:3000"
+        And "canonicalHost" is set to "https://www.cancer.gov"
+        And "siteName" is set to "National Cancer Institute"
+        And "channel" is set to "Search"
+        And "analyticsContentGroup" is set to "Global Search"
+        And "analyticsPublishedDate" is set to "02/02/2011"
+        When the user navigates to "/?swKeyword=breast+cancer"
+        And user types "lung cancer" in the results search box
+        And user submits the results search box
+        Then the SearchBox:Submit EDDL event is raised with previousTerm "breast cancer" and searchTerm "lung cancer"

--- a/cypress/e2e/ResultsSearchBoxAutosuggest.feature
+++ b/cypress/e2e/ResultsSearchBoxAutosuggest.feature
@@ -1,0 +1,29 @@
+Feature: As a user, the results-page search box offers autosuggestions as I type so I can refine my search. (issue #220)
+
+
+    Scenario: Autosuggest options appear, with the typed text bold, when typing 3 or more characters
+        Given "language" is set to "en"
+        And "searchCollection" is set to "cgov"
+        And the autosuggest service returns "lung cancer|lung|small cell lung cancer"
+        When the user navigates to "/?swKeyword=breast+cancer"
+        And user types "lung" in the results search box
+        Then the results search box dropdown displays the options:
+            | lung cancer            |
+            | lung                   |
+            | small cell lung cancer |
+        And the typed text "lung" is bold in each results search box option
+
+    Scenario: A hint is shown below the minimum character count
+        Given "language" is set to "en"
+        When the user navigates to "/?swKeyword=breast+cancer"
+        And user types "lu" in the results search box
+        Then the results search box dropdown displays the message "Please enter 3 or more characters"
+
+    Scenario: Selecting an autosuggest option populates the search box
+        Given "language" is set to "en"
+        And "searchCollection" is set to "cgov"
+        And the autosuggest service returns "lung cancer|lung|small cell lung cancer"
+        When the user navigates to "/?swKeyword=breast+cancer"
+        And user types "lung" in the results search box
+        And user selects the autosuggest option "small cell lung cancer"
+        Then the results search box contains "small cell lung cancer"

--- a/cypress/e2e/ResultsSearchBoxAutosuggestSpanish.feature
+++ b/cypress/e2e/ResultsSearchBoxAutosuggestSpanish.feature
@@ -1,0 +1,29 @@
+Feature: As a Spanish user, the results-page search box offers autosuggestions as I type so I can refine my search. (issue #220)
+
+
+    Scenario: Autosuggest options appear, with the typed text bold, when typing 3 or more characters
+        Given "language" is set to "es"
+        And "searchCollection" is set to "cgov"
+        And the autosuggest service returns "adrenocortical|adrenalectomía|adrenalina"
+        When the user navigates to "/?swKeyword=video"
+        And user types "adre" in the results search box
+        Then the results search box dropdown displays the options:
+            | adrenocortical |
+            | adrenalectomía |
+            | adrenalina     |
+        And the typed text "adre" is bold in each results search box option
+
+    Scenario: A hint is shown below the minimum character count
+        Given "language" is set to "es"
+        When the user navigates to "/?swKeyword=video"
+        And user types "ad" in the results search box
+        Then the results search box dropdown displays the message "Ingrese 3 o más caracteres"
+
+    Scenario: Selecting an autosuggest option populates the search box
+        Given "language" is set to "es"
+        And "searchCollection" is set to "cgov"
+        And the autosuggest service returns "adrenocortical|adrenalectomía|adrenalina"
+        When the user navigates to "/?swKeyword=video"
+        And user types "adre" in the results search box
+        And user selects the autosuggest option "adrenalectomía"
+        Then the results search box contains "adrenalectomía"

--- a/cypress/e2e/common/index.js
+++ b/cypress/e2e/common/index.js
@@ -171,6 +171,78 @@ Then('browser waits', () => {
 	cy.wait(2000);
 });
 
+/*
+    ----------------------------------------
+      Results-page search box (issue #223)
+    ----------------------------------------
+*/
+When('user types {string} in the results search box', (term) => {
+	cy.get('#sws-results-search').clear().type(term);
+});
+
+// Stub the autosuggest endpoint with a deterministic set of terms (pipe-separated).
+Given('the autosuggest service returns {string}', (pipeSeparated) => {
+	const terms = pipeSeparated.split('|').map((t) => t.trim());
+	cy.intercept('GET', '**/Autosuggest/**', {
+		statusCode: 200,
+		body: { results: terms.map((term) => ({ term })), total: terms.length },
+	}).as('autosuggest');
+});
+
+Then('the results search box dropdown displays the options:', (dataTable) => {
+	const expected = dataTable.rawTable.map((row) => row[0]);
+	cy.get('.results-search-box .nci-autocomplete__option').should('have.length', expected.length);
+	expected.forEach((option, i) => {
+		cy.get('.results-search-box .nci-autocomplete__option').eq(i).should('contain.text', option);
+	});
+});
+
+Then('the typed text {string} is bold in each results search box option', (typed) => {
+	cy.get('.results-search-box .nci-autocomplete__option strong')
+		.should('have.length.greaterThan', 0)
+		.each(($el) => {
+			expect($el.text().toLowerCase()).to.contain(typed.toLowerCase());
+		});
+});
+
+Then('the results search box dropdown displays the message {string}', (message) => {
+	cy.get('.results-search-box .nci-autocomplete__status').should('contain.text', message);
+});
+
+When('user selects the autosuggest option {string}', (option) => {
+	cy.get('.results-search-box .nci-autocomplete__option').contains(option).click();
+});
+
+Then('the results search box contains {string}', (value) => {
+	cy.get('#sws-results-search').should('have.value', value);
+});
+
+When('user submits the results search box', () => {
+	// `window.location` can't be stubbed in the iframe (non-configurable + read-only),
+	// so the submit will reload the page and reset NCIDataLayer. The analytics event
+	// is pushed synchronously *before* navigation, so spy on NCIDataLayer.push to
+	// capture it (the spy's recorded calls survive the navigation).
+	cy.window().then((win) => {
+		win.NCIDataLayer = win.NCIDataLayer || [];
+		cy.spy(win.NCIDataLayer, 'push').as('eddlPush');
+	});
+	cy.get('.results-search-box .nci-autocomplete__submit').click();
+});
+
+Then('the SearchBox:Submit EDDL event is raised with previousTerm {string} and searchTerm {string}', (previousTerm, searchTerm) => {
+	cy.get('@eddlPush').should('have.been.calledWithMatch', {
+		type: 'Other',
+		event: 'SiteWideSearchApp:SearchBox:Submit',
+		linkName: 'SiteWideSearchApp:SearchBox:Submit',
+		data: {
+			location: 'Body',
+			formType: 'Search Box',
+			previousTerm,
+			searchTerm,
+		},
+	});
+});
+
 And('the following links and texts exist on the page', (dataTable) => {
 	// Split the data table into array of pairs
 	const rawTable = dataTable.rawTable.slice();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@nciocpl/ncids-css": "^3.4.0",
 				"@nciocpl/ncids-js": "^3.4.0",
-				"@nciocpl/react-components": "^0.1.0",
+				"@nciocpl/react-components": "^0.3.0",
 				"autoprefixer": "^10.4.23",
 				"axios": "^1.6.7",
 				"camelcase": "^5.3.1",
@@ -5111,16 +5111,17 @@
 			"license": "ISC"
 		},
 		"node_modules/@nciocpl/react-components": {
-			"version": "0.1.0",
-			"resolved": "https://npm.pkg.github.com/download/@nciocpl/react-components/0.1.0/2deda14509ad6d30f8b811a71db91716ce3465d4",
-			"integrity": "sha512-+SB42XPn20VAG/y8msDxWPbJEbWJiLxskkTYvy4ilARcAGf4GCopm+5O+5qxbCXrzUv4Q+kXLi/nZ0gHqRmgOw==",
+			"version": "0.3.0",
+			"resolved": "https://npm.pkg.github.com/download/@nciocpl/react-components/0.3.0/14f2427dbb9c78dc263e8f5f17f91fc131dcf61c",
+			"integrity": "sha512-8wcS9UqPsuRQzxQXYN0n71RslO+OR5bIVtLKHeqWrFWBojYse+hZXJ6J5KVBSbYpsR0D9kNXBS7Kn9cQlBGCoA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=20.0.0"
 			},
 			"peerDependencies": {
-				"react": ">=16.14.0",
-				"react-dom": ">=16.14.0"
+				"@nciocpl/ncids-css": ">=3.0.0",
+				"react": ">=17.0.0",
+				"react-dom": ">=17.0.0"
 			}
 		},
 		"node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -32932,9 +32933,9 @@
 			"integrity": "sha512-B054cJCcNX3sNHYkxpGC5JBxA4utKdKBfbAFPSmm1vTt9msTZe2l6+pCA/bmg/yVkG+EThOKpe49tunZ1+O+lA=="
 		},
 		"@nciocpl/react-components": {
-			"version": "0.1.0",
-			"resolved": "https://npm.pkg.github.com/download/@nciocpl/react-components/0.1.0/2deda14509ad6d30f8b811a71db91716ce3465d4",
-			"integrity": "sha512-+SB42XPn20VAG/y8msDxWPbJEbWJiLxskkTYvy4ilARcAGf4GCopm+5O+5qxbCXrzUv4Q+kXLi/nZ0gHqRmgOw=="
+			"version": "0.3.0",
+			"resolved": "https://npm.pkg.github.com/download/@nciocpl/react-components/0.3.0/14f2427dbb9c78dc263e8f5f17f91fc131dcf61c",
+			"integrity": "sha512-8wcS9UqPsuRQzxQXYN0n71RslO+OR5bIVtLKHeqWrFWBojYse+hZXJ6J5KVBSbYpsR0D9kNXBS7Kn9cQlBGCoA=="
 		},
 		"@nicolo-ribaudo/eslint-scope-5-internals": {
 			"version": "5.1.1-v1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	"dependencies": {
 		"@nciocpl/ncids-css": "^3.4.0",
 		"@nciocpl/ncids-js": "^3.4.0",
-		"@nciocpl/react-components": "^0.1.0",
+		"@nciocpl/react-components": "^0.3.0",
 		"autoprefixer": "^10.4.23",
 		"axios": "^1.6.7",
 		"camelcase": "^5.3.1",

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,4 +12,5 @@ export { default as Definition } from './molecules/definition';
 export { FigureCgovImage, FigureCgovVideo } from './molecules/figures';
 export { default as Pronunciation } from './molecules/pronunciation';
 export { default as NoResults } from './molecules/no-results';
+export { default as ResultsSearchBox } from './molecules/results-search-box';
 export { default as SearchResultsList } from './molecules/search-results-list';

--- a/src/components/molecules/results-search-box/__tests__/results-search-box.test.jsx
+++ b/src/components/molecules/results-search-box/__tests__/results-search-box.test.jsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ResultsSearchBox from '../results-search-box';
+
+// Mock the shared Autocomplete so we can drive its callbacks directly and assert
+// the props this molecule passes. The factory is self-contained (no references to
+// outer imports) to satisfy jest hoisting.
+jest.mock('@nciocpl/react-components', () => {
+	const React = require('react');
+	return {
+		__esModule: true,
+		Autocomplete: (props) => {
+			global.__autocompleteProps = props;
+			// eslint-disable-next-line react/prop-types -- test stub, not a real component
+			return React.createElement('div', { 'data-testid': 'autocomplete' }, props.value ? props.value.label : '');
+		},
+	};
+});
+
+const acProps = () => global.__autocompleteProps;
+
+const mockQuery = jest.fn();
+jest.mock('react-fetching-library', () => ({
+	useClient: () => ({ query: mockQuery }),
+}));
+
+jest.mock('../../../../store/store', () => ({
+	useStateValue: () => [{ language: 'en' }],
+}));
+
+jest.mock('../../../../hooks', () => ({
+	useURLQuery: () => new URLSearchParams('?cfg=0'),
+}));
+
+const mockTrackEvent = jest.fn();
+jest.mock('react-tracking', () => ({
+	useTracking: () => ({ trackEvent: mockTrackEvent }),
+}));
+
+describe('ResultsSearchBox', () => {
+	let originalLocation;
+	beforeEach(() => {
+		global.__autocompleteProps = undefined;
+		mockQuery.mockReset();
+		mockTrackEvent.mockReset();
+		originalLocation = window.location;
+		delete window.location;
+		window.location = { assign: jest.fn() };
+	});
+
+	afterEach(() => {
+		window.location = originalLocation;
+	});
+
+	it('passes the keyword through as the controlled value', () => {
+		render(<ResultsSearchBox keyword="grants management" />);
+		expect(screen.getByTestId('autocomplete')).toHaveTextContent('grants management');
+		expect(acProps().value).toEqual({
+			label: 'grants management',
+			value: 'grants management',
+		});
+	});
+
+	it('configures the min-character gate and localized strings', () => {
+		render(<ResultsSearchBox keyword="" />);
+		const props = acProps();
+		expect(props.minChars).toBe(3);
+		expect(props.minCharsMessage).toBe('Please enter 3 or more characters');
+		expect(props.highlightMatch).toBe(true);
+		expect(props.value).toBeNull();
+	});
+
+	it('maps autosuggest API results to options (max 10)', async () => {
+		const results = Array.from({ length: 12 }, (_, i) => ({
+			term: `lung term ${i}`,
+		}));
+		mockQuery.mockResolvedValue({ payload: { results } });
+
+		render(<ResultsSearchBox keyword="" />);
+		const options = await acProps().loadOptions('lung');
+
+		expect(mockQuery).toHaveBeenCalledTimes(1);
+		expect(options).toHaveLength(10);
+		expect(options[0]).toEqual({
+			label: 'lung term 0',
+			value: 'lung term 0',
+		});
+	});
+
+	it('does not call the API below the minimum character count', async () => {
+		render(<ResultsSearchBox keyword="" />);
+		const options = await acProps().loadOptions('lu');
+		expect(mockQuery).not.toHaveBeenCalled();
+		expect(options).toEqual([]);
+	});
+
+	it('returns no options when the API errors', async () => {
+		mockQuery.mockResolvedValue({ error: true, payload: null });
+		render(<ResultsSearchBox keyword="" />);
+		const options = await acProps().loadOptions('lung');
+		expect(options).toEqual([]);
+	});
+
+	it('navigates to the new search on submit, preserving existing params', () => {
+		render(<ResultsSearchBox keyword="" />);
+		acProps().onSubmit('lung cancer');
+		expect(window.location.assign).toHaveBeenCalledWith('?cfg=0&swKeyword=lung+cancer');
+	});
+
+	it('ignores empty submissions', () => {
+		render(<ResultsSearchBox keyword="" />);
+		acProps().onSubmit('   ');
+		expect(window.location.assign).not.toHaveBeenCalled();
+	});
+
+	// Analytics — issue #223
+	it('raises the SearchBox:Submit EDDL event on submit with previous/search terms', () => {
+		render(<ResultsSearchBox keyword="breast cancer" />);
+		acProps().onSubmit('lung cancer');
+		expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+		expect(mockTrackEvent).toHaveBeenCalledWith({
+			type: 'Other',
+			event: 'SiteWideSearchApp:SearchBox:Submit',
+			linkName: 'SiteWideSearchApp:SearchBox:Submit',
+			location: 'Body',
+			formType: 'Search Box',
+			previousTerm: 'breast cancer',
+			searchTerm: 'lung cancer',
+		});
+	});
+
+	it('does not raise the analytics event for an empty submission', () => {
+		render(<ResultsSearchBox keyword="breast cancer" />);
+		acProps().onSubmit('   ');
+		expect(mockTrackEvent).not.toHaveBeenCalled();
+	});
+
+	it('only populates the box when a suggestion is selected — no search, no analytics', async () => {
+		const results = [{ term: 'lung cancer' }, { term: 'lung cancer treatment' }];
+		mockQuery.mockResolvedValue({ payload: { results } });
+		render(<ResultsSearchBox keyword="breast cancer" />);
+
+		// The user types "lung can", the dropdown loads, then they pick option #2.
+		const options = await acProps().loadOptions('lung can');
+		acProps().onChange(options[1]);
+
+		expect(mockTrackEvent).not.toHaveBeenCalled();
+		expect(window.location.assign).not.toHaveBeenCalled();
+	});
+
+	it('reports the autosuggest data elements when a selected suggestion is then submitted', async () => {
+		const results = [{ term: 'lung cancer' }, { term: 'lung cancer treatment' }];
+		mockQuery.mockResolvedValue({ payload: { results } });
+		render(<ResultsSearchBox keyword="breast cancer" />);
+
+		// Types "lung can", picks option #2 (populates the box), then submits it.
+		const options = await acProps().loadOptions('lung can');
+		acProps().onChange(options[1]);
+		acProps().onSubmit('lung cancer treatment');
+
+		expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+		expect(mockTrackEvent).toHaveBeenCalledWith({
+			type: 'Other',
+			event: 'SiteWideSearchApp:SearchBox:Submit',
+			linkName: 'SiteWideSearchApp:SearchBox:Submit',
+			location: 'Body',
+			formType: 'Search Box',
+			previousTerm: 'breast cancer',
+			searchTerm: 'lung cancer treatment',
+			autoSuggestUsage: 'Selected',
+			charactersTyped: 'lung can',
+			numCharacters: 8,
+			numSuggestsSelected: 1,
+			suggestItems: 2,
+		});
+		expect(window.location.assign).toHaveBeenCalledWith('?cfg=0&swKeyword=lung+cancer+treatment');
+	});
+
+	it('treats a submit after the selection is edited as a plain typed search', async () => {
+		const results = [{ term: 'lung cancer' }, { term: 'lung cancer treatment' }];
+		mockQuery.mockResolvedValue({ payload: { results } });
+		render(<ResultsSearchBox keyword="breast cancer" />);
+
+		const options = await acProps().loadOptions('lung can');
+		acProps().onChange(options[1]);
+		// Editing the box after a selection fires onChange(null); the pending
+		// autosuggest context should be dropped.
+		acProps().onChange(null);
+		acProps().onSubmit('lung cancer treatment');
+
+		const payload = mockTrackEvent.mock.calls[0][0];
+		expect(payload.autoSuggestUsage).toBeUndefined();
+		expect(window.location.assign).toHaveBeenCalledWith('?cfg=0&swKeyword=lung+cancer+treatment');
+	});
+
+	it('does not include autosuggest data elements on a plain typed submit', () => {
+		render(<ResultsSearchBox keyword="breast cancer" />);
+		acProps().onSubmit('lung cancer');
+		const payload = mockTrackEvent.mock.calls[0][0];
+		expect(payload.autoSuggestUsage).toBeUndefined();
+		expect(payload.charactersTyped).toBeUndefined();
+		expect(payload.numCharacters).toBeUndefined();
+		expect(payload.numSuggestsSelected).toBeUndefined();
+		expect(payload.suggestItems).toBeUndefined();
+	});
+
+	it('ignores onChange(null) fired when the box is cleared or edited', () => {
+		render(<ResultsSearchBox keyword="breast cancer" />);
+		acProps().onChange(null);
+		expect(mockTrackEvent).not.toHaveBeenCalled();
+		expect(window.location.assign).not.toHaveBeenCalled();
+	});
+});

--- a/src/components/molecules/results-search-box/index.js
+++ b/src/components/molecules/results-search-box/index.js
@@ -1,0 +1,1 @@
+export { default } from './results-search-box';

--- a/src/components/molecules/results-search-box/results-search-box.jsx
+++ b/src/components/molecules/results-search-box/results-search-box.jsx
@@ -1,0 +1,138 @@
+import PropTypes from 'prop-types';
+import React, { useRef } from 'react';
+import { useClient } from 'react-fetching-library';
+import { useTracking } from 'react-tracking';
+import { Autocomplete } from '@nciocpl/react-components';
+
+import { useURLQuery } from '../../../hooks';
+import { getAutosuggestResults } from '../../../services/api/actions';
+import { useStateValue } from '../../../store/store';
+import { i18n } from '../../../utils';
+
+const MIN_CHARS = 3;
+const MAX_SUGGESTIONS = 10;
+
+/**
+ * Search box shown on the results page. Wraps the shared NCIDS Autocomplete:
+ * loads term suggestions from the Site-wide Search Autosuggest API, displays
+ * the active keyword, and performs a new search on submit.
+ */
+const ResultsSearchBox = ({ keyword = '' }) => {
+	const client = useClient();
+	const urlQuery = useURLQuery();
+	const tracking = useTracking();
+	const [{ language }] = useStateValue();
+
+	// The shared Autocomplete's onSubmit/onChange callbacks don't report what the
+	// user typed or which suggestions were shown, so we capture that here to
+	// populate the autosuggest data elements on selection (issue #223).
+	const shownOptionsRef = useRef([]);
+	const typedValueRef = useRef('');
+
+	// Selecting a suggestion only populates the box; it doesn't search until the
+	// user submits. We stash the autosuggest data elements captured at selection
+	// time here so a later submit of that same term can report them. Cleared when
+	// the box is edited or cleared, since the pending term no longer applies.
+	const pendingAutosuggestRef = useRef(null);
+
+	const loadOptions = async (inputValue) => {
+		typedValueRef.current = inputValue;
+		const term = inputValue.trim();
+		if (term.length < MIN_CHARS) {
+			shownOptionsRef.current = [];
+			return [];
+		}
+
+		const { payload, error } = await client.query(getAutosuggestResults({ term, size: MAX_SUGGESTIONS }));
+
+		if (error || !payload || !Array.isArray(payload.results)) {
+			shownOptionsRef.current = [];
+			return [];
+		}
+
+		const options = payload.results.slice(0, MAX_SUGGESTIONS).map((item) => ({ label: item.term, value: item.term }));
+		shownOptionsRef.current = options;
+		return options;
+	};
+
+	// Raise the EDDL search-box submit event before navigating (the push is
+	// synchronous). `previousTerm` is the keyword the box was populated with
+	// before edits; `searchTerm` is what was actually submitted. `autosuggest`
+	// carries the extra data elements when the search came from an autosuggest
+	// selection; it is omitted for a plain typed submit, leaving those fields
+	// undefined as specified. See issue #223.
+	const submitSearch = (rawValue, autosuggest) => {
+		const term = (rawValue || '').trim();
+		if (term === '') {
+			return;
+		}
+
+		tracking.trackEvent({
+			type: 'Other',
+			event: 'SiteWideSearchApp:SearchBox:Submit',
+			linkName: 'SiteWideSearchApp:SearchBox:Submit',
+			location: 'Body',
+			formType: 'Search Box',
+			previousTerm: keyword,
+			searchTerm: term,
+			...autosuggest,
+		});
+
+		// Preserve the existing query string (e.g. cfg), swap in the new keyword
+		// and reset paging. A full-page navigation matches the rest of the app and
+		// lets the host re-read its configuration. `assign` (vs `location.href =`)
+		// is behaviorally identical but stubbable in tests.
+		urlQuery.set('swKeyword', term);
+		urlQuery.delete('page');
+		urlQuery.delete('pageunit');
+		window.location.assign(`?${urlQuery.toString()}`);
+	};
+
+	// Enter / search-button submit. If the value being submitted is exactly the
+	// suggestion the user selected (and hasn't since edited), report the captured
+	// autosuggest data elements; otherwise it's a plain typed submit.
+	const handleSubmit = (value) => {
+		const pending = pendingAutosuggestRef.current;
+		const autosuggest = pending && pending.term === (value || '').trim() ? pending.data : undefined;
+		submitSearch(value, autosuggest);
+	};
+
+	// Selecting a suggestion only populates the box (the shared Autocomplete
+	// fills its own input) — it must NOT trigger a search. Capture the autosuggest
+	// usage so an explicit submit of this term can report it. onChange also fires
+	// with null when the box is cleared or edited: drop the pending term then, so
+	// a subsequent submit is treated as a plain typed search (issue #223).
+	const handleChange = (option) => {
+		if (!option) {
+			pendingAutosuggestRef.current = null;
+			return;
+		}
+
+		const typed = typedValueRef.current;
+		pendingAutosuggestRef.current = {
+			term: option.value.trim(),
+			data: {
+				autoSuggestUsage: 'Selected',
+				charactersTyped: typed,
+				numCharacters: typed.length,
+				numSuggestsSelected: shownOptionsRef.current.findIndex((o) => o.value === option.value),
+				suggestItems: shownOptionsRef.current.length,
+			},
+		};
+	};
+
+	const value = keyword ? { label: keyword, value: keyword } : null;
+
+	return (
+		<div className="results-search-box">
+			<Autocomplete id="sws-results-search" className="results-search-box__autocomplete" label={i18n.search[language]} minChars={MIN_CHARS} minCharsMessage={i18n.pleaseEnterThreeOrMoreCharacters[language]} highlightMatch loadOptions={loadOptions} onChange={handleChange} onSubmit={handleSubmit} searchButtonLabel={i18n.search[language]} value={value} />
+		</div>
+	);
+};
+
+ResultsSearchBox.propTypes = {
+	/** Current search keyword to display in the box. */
+	keyword: PropTypes.string,
+};
+
+export default ResultsSearchBox;

--- a/src/components/molecules/results-search-box/results-search-box.scss
+++ b/src/components/molecules/results-search-box/results-search-box.scss
@@ -1,0 +1,197 @@
+@use 'uswds-core' as *;
+@use '../../../styles/breakpoints' as *;
+
+// The shared @nciocpl/react-components Autocomplete reuses NCIDS `nci-autocomplete*`
+// class names, so the embedded NCIDS stylesheet styles much of it already. All
+// colors here come from the NCIDS theme (`color()` / `$theme-*`), never hardcoded
+// hex; only layout/size — this page's choices — and the React-vs-NCIDS structural
+// deltas (a flex wrapper, a hidden listbox, an sr-only status row) are set
+// explicitly. Everything is scoped under the app root id so it outranks the host's
+// `.nci-autocomplete*` rules and stays confined to this app (the host header search
+// is untouched).
+//
+// Sizing per Figma — mobile (base): ~448px box, 40px tall; desktop
+// (`break(medium)`, ≥641px): ~528px box, 32px tall ("small").
+//
+// Scoped to both the production root id (`#NCI-sws-app-root`) and the local/
+// standalone default (`#NCI-app-root`, set in public/index.html) so the styles
+// apply in every environment.
+#NCI-sws-app-root,
+#NCI-app-root {
+	.results-search-box {
+		margin-bottom: 1.5rem;
+
+		// Intent is conveyed by the placeholder and the search button, so the
+		// Autocomplete's label is visually hidden but kept for screen readers.
+		.usa-label {
+			position: absolute;
+			left: -999em;
+			overflow: hidden;
+		}
+
+		.nci-autocomplete {
+			display: block; // host NCIDS sets `display: flex`
+			position: relative;
+			width: 100%;
+			max-width: 28rem; // mobile ~448px
+
+			@include break(medium) {
+				max-width: 33rem; // desktop ~528px
+			}
+
+			&__control {
+				display: flex;
+				align-items: stretch;
+			}
+
+			&__field {
+				position: relative;
+				flex: 1 1 auto;
+				display: flex;
+				align-items: center;
+			}
+
+			&__input {
+				width: 100%;
+				height: 2.5rem; // mobile ~40px
+				margin: 0;
+				padding: 0 2rem 0 0.625rem; // 10px text inset; 2rem right for the clear (×)
+				border: 1px solid color('base-dark');
+				border-radius: 0;
+				background-color: color('white'); // override the legacy #f2f2f3 input bg
+				color: color('ink');
+				box-shadow: none;
+				font-size: 1rem;
+
+				@include break(medium) {
+					height: 2rem; // desktop "small" ~32px
+				}
+			}
+
+			&__clear {
+				position: absolute;
+				right: 0.5rem;
+				top: 50%;
+				transform: translateY(-50%);
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				width: 1.5rem; // 24px icon box
+				height: 1.5rem;
+				background: none;
+				border: none;
+				cursor: pointer;
+				font-size: 1.5rem; // × glyph ≈ 14px
+				line-height: 1;
+				padding: 0;
+				color: color('base');
+
+				&:hover {
+					color: color('ink');
+				}
+
+				&:focus {
+					outline: 0.25rem solid color($theme-focus-color);
+					outline-offset: 0;
+				}
+			}
+
+			&__submit {
+				flex: 0 0 auto;
+				display: inline-flex;
+				align-items: center;
+				justify-content: center;
+				width: 3rem;
+				height: 2.5rem; // match the mobile input height
+				margin: 0;
+				padding: 0;
+				border: none;
+				background-color: color('primary'); // #007BBD from the NCIDS theme
+				color: color('white');
+				cursor: pointer;
+
+				@include break(medium) {
+					height: 2rem; // match the desktop input height
+				}
+
+				&:hover {
+					background-color: color('primary-dark');
+				}
+
+				&:focus {
+					outline: 0.25rem solid color($theme-focus-color);
+					outline-offset: 0;
+				}
+
+				&:disabled {
+					background-color: color('disabled-light');
+					cursor: not-allowed;
+				}
+
+				svg {
+					width: 1.5rem;
+					height: 1.5rem;
+					fill: currentColor;
+				}
+			}
+
+			// host NCIDS keeps the listbox `display: none` (shown only via `.active`).
+			&__listbox {
+				display: block;
+				position: absolute;
+				z-index: 400; // above the NCIDS header listbox (z-index 301)
+				top: 100%;
+				left: 0;
+				right: 3rem; // align to the input width (exclude the 3rem button)
+				background-color: color('white');
+				border: 1px solid color('base-dark');
+				border-radius: 0;
+				list-style: none;
+				margin: 0;
+				padding: 0;
+				max-height: 15rem;
+				overflow-y: auto;
+
+				&[hidden] {
+					display: none;
+				}
+			}
+
+			&__option {
+				padding: 0.5rem 0.5rem 0.5rem 1rem; // 8 / 8 / 8 / 16 per Figma
+				cursor: pointer;
+				font-size: 0.875rem; // 14px
+				line-height: 21px;
+				color: color('ink');
+
+				strong {
+					font-weight: 700;
+				}
+
+				// selected / keyboard-highlighted (and hover) per Figma
+				&:hover,
+				&--highlighted {
+					background-color: color('primary');
+					color: color('white');
+					outline: none;
+				}
+			}
+
+			// host NCIDS renders the status row sr-only; keep ours visible.
+			&__status {
+				position: static;
+				width: auto;
+				height: auto;
+				margin: 0;
+				padding: 0.5rem 1rem;
+				overflow: visible;
+				clip: auto;
+				clip-path: none;
+				white-space: normal;
+				color: color('base');
+				font-style: italic;
+				cursor: default;
+			}
+		}
+	}
+}

--- a/src/components/molecules/search-results-list/search-results-list.scss
+++ b/src/components/molecules/search-results-list/search-results-list.scss
@@ -121,3 +121,46 @@
 	background-size: .5rem !important;
 	background-position: right 1rem center !important;
 }
+
+// Result-item typography per Figma. Scoped under the app root id so it outranks
+// the host's `usa-collection__*` styles and stays confined to this app.
+// (Item-to-item spacing is the existing 24px `.sws-results__list-item` margin.)
+// Both ids: production (`#NCI-sws-app-root`) and local/standalone (`#NCI-app-root`).
+#NCI-sws-app-root,
+#NCI-app-root {
+	.sws-results__list-item {
+		// Title: Poppins 20px 600, underlined, #01679D
+		.usa-collection__heading {
+			@include u-font-family('heading');
+			font-size: 1.25rem; // 20px
+			font-weight: 600;
+			line-height: 24px;
+			margin-bottom: 0.75rem; // 12px to the body text
+
+			a,
+			.usa-link {
+				&,
+				&:visited {
+					color: #01679d;
+				}
+				text-decoration: underline;
+			}
+		}
+
+		// Body + URL: Open Sans 16px 400, #1B1B1B
+		.usa-collection__description,
+		.sws-results__list-item-url {
+			@include u-font-family('body');
+			font-size: 1rem; // 16px
+			font-weight: 400;
+			line-height: 24px;
+			color: #1b1b1b;
+		}
+
+		.sws-results__list-item-url {
+			display: block;
+			font-style: normal; // <cite> defaults to italic
+			word-break: break-word;
+		}
+	}
+}

--- a/src/services/api/actions/__tests__/getAutosuggestResults.test.js
+++ b/src/services/api/actions/__tests__/getAutosuggestResults.test.js
@@ -1,0 +1,30 @@
+import { getAutosuggestResults } from '../index';
+
+describe('getAutosuggestResults action', () => {
+	it('should match autosuggest action for term "lung" with default size', () => {
+		const term = 'lung';
+		const expectedAction = {
+			interceptorName: 'sitewide-search-api',
+			method: 'GET',
+			endpoint: `{{API_HOST}}/Autosuggest/{{COLLECTION}}/{{LANGUAGE}}/${encodeURIComponent(term)}?size=10`,
+		};
+		expect(getAutosuggestResults({ term })).toEqual(expectedAction);
+	});
+
+	it('should honor a custom size', () => {
+		const term = 'adre';
+		const expectedAction = {
+			interceptorName: 'sitewide-search-api',
+			method: 'GET',
+			endpoint: `{{API_HOST}}/Autosuggest/{{COLLECTION}}/{{LANGUAGE}}/${encodeURIComponent(term)}?size=5`,
+		};
+		expect(getAutosuggestResults({ term, size: 5 })).toEqual(expectedAction);
+	});
+
+	it('should encode terms with spaces and accents', () => {
+		const term = 'adrenalectomía cáncer';
+		const action = getAutosuggestResults({ term });
+		expect(action.endpoint).toContain(encodeURIComponent(term));
+		expect(action.endpoint).not.toContain(' ');
+	});
+});

--- a/src/services/api/actions/getAutosuggestResults.js
+++ b/src/services/api/actions/getAutosuggestResults.js
@@ -1,0 +1,14 @@
+/**
+ * Gets autosuggest term suggestions from the Site-wide Search API.
+ *
+ * @param {Object} params parameters for the API call
+ * @param {string} params.term the partial keyword to get suggestions for
+ * @param {number} params.size maximum number of suggestions to return
+ */
+export const getAutosuggestResults = ({ term, size = 10 }) => {
+	return {
+		interceptorName: 'sitewide-search-api',
+		method: 'GET',
+		endpoint: `{{API_HOST}}/Autosuggest/{{COLLECTION}}/{{LANGUAGE}}/${encodeURIComponent(term)}?size=${size}`,
+	};
+};

--- a/src/services/api/actions/index.js
+++ b/src/services/api/actions/index.js
@@ -1,3 +1,4 @@
+export { getAutosuggestResults } from './getAutosuggestResults';
 export { getBestBetResults } from './getBestBetResults';
 export { getDictionaryResults } from './getDictionaryResults';
 export { getSearchResults } from './getSearchResults';

--- a/src/styles/digital-platform-mock-wrapper.scss
+++ b/src/styles/digital-platform-mock-wrapper.scss
@@ -2,6 +2,12 @@
 @forward 'ncids-application-page';
 @forward "usa-footer";
 @forward "nci-header";
+// The header search box and our results search box both use the NCIDS
+// `nci-autocomplete` component. The full Drupal shell ships these styles; this
+// mock shell needs them too so the search boxes aren't unstyled locally / in the
+// standalone preview. (App-specific overrides live in results-search-box.scss,
+// scoped under #NCI-sws-app-root, and only patch the React-vs-NCIDS deltas.)
+@forward "nci-autocomplete";
 @forward "usa-banner";
 
 @forward "usa-button";

--- a/src/styles/sitewide-search.scss
+++ b/src/styles/sitewide-search.scss
@@ -7,6 +7,7 @@
 @use '../components/molecules/best-bet/best-bet';
 @use '../components/molecules/definition/definition';
 @use '../components/molecules/pronunciation/pronunciation';
+@use '../components/molecules/results-search-box/results-search-box';
 @use '../components/molecules/search-results-list/search-results-list.scss';
 
 //views
@@ -89,57 +90,65 @@ ul li ul {
 	font-size: 1em;
 }
 
-input[type='checkbox'],
-input[type='file'],
-input[type='radio'],
-select {
-	margin: 0 0 1em;
-}
+// Legacy form styling scoped under the app root id so these bare `input`/`select`
+// element selectors don't leak onto the embedded Drupal/NCIDS page (e.g. the host
+// header search box, which is `input[type='search']`). `input[type='search']`
+// (0,1,1) otherwise beats the host's `.usa-input` (0,1,0). Both ids: production
+// (`#NCI-sws-app-root`) and local/standalone (`#NCI-app-root`).
+#NCI-sws-app-root,
+#NCI-app-root {
+	input[type='checkbox'],
+	input[type='file'],
+	input[type='radio'],
+	select {
+		margin: 0 0 1em;
+	}
 
-input[type='date'],
-input[type='datetime-local'],
-input[type='datetime'],
-input[type='email'],
-input[type='month'],
-input[type='number'],
-input[type='password'],
-input[type='search'],
-input[type='tel'],
-input[type='text'],
-input[type='time'],
-input[type='url'],
-input[type='week'],
-textarea {
-	border-radius: 0;
-	background-color: #f2f2f3;
-	font-family: inherit;
-	-webkit-box-shadow: 0 2px 4px 0 hsla(240, 4%, 95%, 0.05) inset;
-	box-shadow: inset 0 2px 4px 0 hsla(240, 4%, 95%, 0.05);
-	color: #2e2e2e;
-	display: block;
-	font-size: 1em;
-	margin: 0 0 1em;
-	padding: 0.5em;
-	height: 2.4375em;
-	width: 100%;
-	-webkit-box-sizing: border-box;
-	box-sizing: border-box;
-	-webkit-transition: -webkit-box-shadow 0.45s, border-color 0.45s ease-in-out;
-	-webkit-transition: border-color 0.45s ease-in-out, -webkit-box-shadow 0.45s;
-	transition: border-color 0.45s ease-in-out, -webkit-box-shadow 0.45s;
-	transition: box-shadow 0.45s, border-color 0.45s ease-in-out;
-	transition: box-shadow 0.45s, border-color 0.45s ease-in-out,
-		-webkit-box-shadow 0.45s;
-}
+	input[type='date'],
+	input[type='datetime-local'],
+	input[type='datetime'],
+	input[type='email'],
+	input[type='month'],
+	input[type='number'],
+	input[type='password'],
+	input[type='search'],
+	input[type='tel'],
+	input[type='text'],
+	input[type='time'],
+	input[type='url'],
+	input[type='week'],
+	textarea {
+		border-radius: 0;
+		background-color: #f2f2f3;
+		font-family: inherit;
+		-webkit-box-shadow: 0 2px 4px 0 hsla(240, 4%, 95%, 0.05) inset;
+		box-shadow: inset 0 2px 4px 0 hsla(240, 4%, 95%, 0.05);
+		color: #2e2e2e;
+		display: block;
+		font-size: 1em;
+		margin: 0 0 1em;
+		padding: 0.5em;
+		height: 2.4375em;
+		width: 100%;
+		-webkit-box-sizing: border-box;
+		box-sizing: border-box;
+		-webkit-transition: -webkit-box-shadow 0.45s, border-color 0.45s ease-in-out;
+		-webkit-transition: border-color 0.45s ease-in-out, -webkit-box-shadow 0.45s;
+		transition: border-color 0.45s ease-in-out, -webkit-box-shadow 0.45s;
+		transition: box-shadow 0.45s, border-color 0.45s ease-in-out;
+		transition: box-shadow 0.45s, border-color 0.45s ease-in-out,
+			-webkit-box-shadow 0.45s;
+	}
 
-// Jump Menu select css
-select {
-	width: auto;
-	font-size: inherit;
-	font-family: Noto Sans, Century Gothic, Arial, sans-serif;
-	color: #2e2e2e;
-	line-height: 1;
-	padding: 0.5em 1em 0.5em 0.75em;
+	// Jump Menu select css
+	select {
+		width: auto;
+		font-size: inherit;
+		font-family: Noto Sans, Century Gothic, Arial, sans-serif;
+		color: #2e2e2e;
+		line-height: 1;
+		padding: 0.5em 1em 0.5em 0.75em;
+	}
 }
 
 // Utility classes for layout

--- a/src/utils/i18n.js
+++ b/src/utils/i18n.js
@@ -35,6 +35,10 @@ export const i18n = {
 		en: 'Please check your spelling or try another search using a different word.',
 		es: 'Revise si hay errores en el texto ingresado o intente otra búsqueda.',
 	},
+	pleaseEnterThreeOrMoreCharacters: {
+		en: 'Please enter 3 or more characters',
+		es: 'Ingrese 3 o más caracteres',
+	},
 	resultsFor: {
 		en: 'Results for',
 		es: 'Resultados para',

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useTracking } from 'react-tracking';
 
-import { BestBet, Definition, NoResults, SearchResultsList, Spinner } from '../../components';
+import { BestBet, Definition, NoResults, ResultsSearchBox, SearchResultsList, Spinner } from '../../components';
 import { useCustomQuery, useURLQuery } from '../../hooks';
 import { getBestBetResults, getDictionaryResults, getSearchResults } from '../../services/api/actions';
 import { useStateValue } from '../../store/store';
@@ -102,6 +102,7 @@ const Home = () => {
 	return (
 		<>
 			<h1>{title}</h1>
+			{keyword && <ResultsSearchBox keyword={keyword} />}
 			{doneLoading && hasResults ? (
 				<div className="results">
 					{isFirstPage && (


### PR DESCRIPTION
Implements the results-page search box. Wraps @nciocpl/react-components Autocomplete in a ResultsSearchBox

- Adds @nciocpl/react-components 
- Adds Dependabot cooldown matching .npmrc min-release-age.
- Adds analytics and tests


Closes #220
Closes #223