### PR TITLE
(#108) Sitewide Search App triggers app reload when using pager

### DIFF
--- a/src/components/atomic/spinner/Spinner.scss
+++ b/src/components/atomic/spinner/Spinner.scss
@@ -13,7 +13,7 @@
 	width: 100px;
 	height: 100px;
 	position: relative;
-	top: -15px;
+	top: 100px;
 	text-align: center;
 }
 

--- a/src/components/molecules/search-results-pager/__tests__/search-results-pager.test.jsx
+++ b/src/components/molecules/search-results-pager/__tests__/search-results-pager.test.jsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 
 import SearchResultsPager from '../search-results-pager';
 import { useStateValue } from '../../../../store/store.jsx';
@@ -18,9 +18,15 @@ const mockState = {
 	title: 'NCI Search Results',
 };
 
+const LocationDisplay = () => {
+	const location = useLocation();
+	return <div data-testid="location">{location.search}</div>;
+};
+
 const renderPager = (props = {}) =>
 	render(
 		<MemoryRouter initialEntries={['/?swKeyword=tumor']}>
+			<LocationDisplay />
 			<SearchResultsPager testid={testIds.RESULTS_PAGER_TOP} current={1} totalResults={200} resultsPerPage={20} language="en" keyword="tumor" {...props} />
 		</MemoryRouter>
 	);
@@ -59,13 +65,9 @@ describe('<SearchResultsPager />', () => {
 		expect(screen.getByText('Siguiente')).toBeInTheDocument();
 	});
 
-	it('navigates to the selected page via window.location.href', () => {
-		Object.defineProperty(window, 'location', {
-			writable: true,
-			value: { href: '' },
-		});
+	it('updates the router location for the selected page without a full page navigation', () => {
 		renderPager({ current: 1 });
 		fireEvent.click(screen.getByRole('link', { name: 'Page 2' }));
-		expect(window.location.href).toBe('?swKeyword=tumor&page=2&pageunit=20');
+		expect(screen.getByTestId('location')).toHaveTextContent('?swKeyword=tumor&page=2&pageunit=20');
 	});
 });

--- a/src/components/molecules/search-results-pager/search-results-pager.jsx
+++ b/src/components/molecules/search-results-pager/search-results-pager.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { i18n } from '../../../utils';
 import { useURLQuery } from '../../../hooks';
@@ -25,6 +26,7 @@ const buildPageWindow = (current, pageCount) => {
 };
 
 const SearchResultsPager = ({ current, totalResults, testid = 'tid-results-pager', keyword, resultsPerPage, language = 'en' }) => {
+	const navigate = useNavigate();
 	const urlQuery = useURLQuery();
 	const pageCount = Math.ceil(totalResults / resultsPerPage);
 
@@ -39,11 +41,11 @@ const SearchResultsPager = ({ current, totalResults, testid = 'tid-results-pager
 		urlQuery.delete('true');
 		urlQuery.set('page', page.toString());
 		urlQuery.set('pageunit', resultsPerPage);
-		window.location.href = `?${urlQuery.toString()}`;
+		navigate({ search: `?${urlQuery.toString()}` });
 	};
 
-	const handleClick = (e, page) => {
-		e.preventDefault();
+	const handleClick = (page) => {
+		// e.preventDefault();
 		navigateTo(page);
 	};
 
@@ -57,7 +59,7 @@ const SearchResultsPager = ({ current, totalResults, testid = 'tid-results-pager
 				<ul className="usa-pagination__list">
 					{showPrevious && (
 						<li className="usa-pagination__item usa-pagination__arrow">
-							<a href="#" className="usa-pagination__link usa-pagination__previous-page" aria-label="Previous page" role="button" onClick={(e) => handleClick(e, currentPage - 1)}>
+							<a href="#" className="usa-pagination__link usa-pagination__previous-page" aria-label="Previous page" role="button" onClick={() => handleClick(currentPage - 1)}>
 								<span className="usa-pagination__link-text">{i18n.previous[language]}</span>
 							</a>
 						</li>
@@ -80,7 +82,7 @@ const SearchResultsPager = ({ current, totalResults, testid = 'tid-results-pager
 						const isCurrent = item === currentPage;
 						return (
 							<li key={`page-${item}`} className="usa-pagination__item usa-pagination__page-no">
-								<a href="#" className={`usa-pagination__button${isCurrent ? ' usa-current' : ''}`} aria-label={`Page ${item}`} aria-current={isCurrent ? 'page' : undefined} onClick={(e) => handleClick(e, item)}>
+								<a href="#" className={`usa-pagination__button${isCurrent ? ' usa-current' : ''}`} aria-label={`Page ${item}`} aria-current={isCurrent ? 'page' : undefined} onClick={() => handleClick(item)}>
 									{item}
 								</a>
 							</li>
@@ -88,7 +90,7 @@ const SearchResultsPager = ({ current, totalResults, testid = 'tid-results-pager
 					})}
 					{showNext && (
 						<li className="usa-pagination__item usa-pagination__arrow">
-							<a href="#" className="usa-pagination__link usa-pagination__next-page" aria-label="Next page" role="button" onClick={(e) => handleClick(e, currentPage + 1)}>
+							<a href="#" className="usa-pagination__link usa-pagination__next-page" aria-label="Next page" role="button" onClick={() => handleClick(currentPage + 1)}>
 								<span className="usa-pagination__link-text">{i18n.next[language]}</span>
 							</a>
 						</li>

--- a/src/views/Home/Home.jsx
+++ b/src/views/Home/Home.jsx
@@ -19,8 +19,8 @@ const Home = () => {
 	const keyword = urlQuery.get('swKeyword') || urlQuery.get('swkeyword');
 	const currentPage = parseInt(urlQuery.get('page'), 10) || 1;
 	const unit = parseInt(urlQuery.get('pageunit'), 10) || 20;
-	const [pageunit] = useState(unit);
-	const [current] = useState(currentPage);
+	const [pageunit, setPageunit] = useState(unit);
+	const [current, setCurrent] = useState(currentPage);
 	const isFirstPage = !urlQuery.get('page') || urlQuery.get('page') === '1';
 
 	const showBestBet = isBestBetsConfigured && stateBestBetResult?.length > 0;
@@ -42,6 +42,18 @@ const Home = () => {
 	// Set hasResults should there be results returned for any search
 	// when a keyword has been provided
 	const hasResults = !!keyword && (stateDefinitionResult?.results?.length > 0 || stateSearchResults?.result?.length > 0 || stateBestBetResult?.length > 0);
+
+	useEffect(() => {
+		setCurrent(currentPage);
+		setPageunit(unit);
+		setDoneLoading(false);
+		setBestBetResultsLoaded(false);
+		setDictionaryResultsLoaded(false);
+		setSearchResultsLoaded(false);
+		setStateBestBetResult(undefined);
+		setStateDefinitionResult(undefined);
+		setStateSearchResults(undefined);
+	}, [currentPage, unit]);
 
 	useEffect(() => {
 		// If no keyword was provided set doneLoading to true and early exit


### PR DESCRIPTION
* Adds useEffect to handle page query changes in Home.jsx
* Updates search-results-pager to use navigate instead of window.location.href
* Removes e.preventDefault from pager handleClick
* Updates search-results-pager.test

Closes #108